### PR TITLE
Horizontal overflow in about section from long strings e.g. urls

### DIFF
--- a/src/components/profile/view/RenderedProfile.tsx
+++ b/src/components/profile/view/RenderedProfile.tsx
@@ -108,7 +108,10 @@ export function RenderedProfile({
           <div className="text-xs tracking-wide text-gray-500 uppercase">
             About
           </div>
-          <RichText text={description} className="mt-1 block text-gray-900" />
+          <RichText
+            text={description}
+            className="mt-1 block break-words text-gray-900"
+          />
         </div>
       )}
 


### PR DESCRIPTION
This was kinda bothering me 😅

before:
<img width="851" height="352" alt="Screenshot 2026-03-10 at 17 55 42" src="https://github.com/user-attachments/assets/c1bb0e63-4028-4911-888a-6b6fc25532f5" />

after:
<img width="699" height="352" alt="Screenshot 2026-03-10 at 17 55 07" src="https://github.com/user-attachments/assets/50a7a1a5-f1ff-45dd-aac5-feef01364f39" />
