### PR TITLE
fix: add grab handle and fix height of cards

### DIFF
--- a/src/components/profile/BackFace.tsx
+++ b/src/components/profile/BackFace.tsx
@@ -58,7 +58,7 @@ export function BackFace({
   return (
     <div
       data-theme={theme}
-      className={`${isBackFace ? "absolute inset-0" : "relative max-h-[85dvh] min-h-[85dvh]"} bg-card text-card-foreground flex flex-col overflow-hidden ${cardClasses}`}
+      className={`${isBackFace ? "absolute inset-0" : "relative max-h-[78dvh] sm:max-h-[85dvh]"} bg-card text-card-foreground flex flex-col overflow-auto sm:overflow-hidden ${cardClasses}`}
       style={containerStyle}
     >
       <div

--- a/src/components/profile/FlippableProfileCard.tsx
+++ b/src/components/profile/FlippableProfileCard.tsx
@@ -133,7 +133,9 @@ export function FlippableProfileCard({
         )}
       </div>
       <div className="pt-6" />
-      <ProfileView {...profileProps} />
+      <div {...dragHandleProps}>
+        <ProfileView {...profileProps} />
+      </div>
       {talks.length > 0 && (
         <div className="mt-4">
           <div className="text-muted-foreground mb-2 text-xs tracking-wide uppercase">
@@ -152,10 +154,10 @@ export function FlippableProfileCard({
   // Reduced motion: skip 3D flip, just swap faces instantly
   if (prefersReducedMotion) {
     return (
-      <div className="mx-auto my-12 max-w-2xl" data-theme={theme}>
+      <div className="mx-auto my-auto max-w-2xl" data-theme={theme}>
         {!flipped ? (
           <div
-            className={`bg-card text-card-foreground relative flex max-h-[85dvh] min-h-[85dvh] flex-col justify-center overflow-auto ${cardClasses}`}
+            className={`bg-card text-card-foreground relative flex max-h-[85dvh] max-h-[78dvh] sm:max-h-[85dvh] flex-col overflow-auto ${cardClasses}`}
           >
             {frontFaceContent}
           </div>
@@ -175,7 +177,7 @@ export function FlippableProfileCard({
 
   return (
     <div
-      className="mx-auto my-12 max-w-2xl"
+      className="mx-auto my-auto max-w-2xl"
       data-theme={theme}
       style={{ perspective: "1200px" }}
     >
@@ -188,7 +190,7 @@ export function FlippableProfileCard({
       >
         {/* Front face — conference profile */}
         <div
-          className={`bg-card text-card-foreground relative flex min-h-[85dvh] flex-col justify-center overflow-auto ${cardClasses}`}
+          className={`bg-card text-card-foreground relative flex max-h-[78dvh] sm:max-h-[85dvh] flex-col overflow-auto ${cardClasses}`}
           style={{
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",

--- a/src/components/profile/ProfilePage.astro
+++ b/src/components/profile/ProfilePage.astro
@@ -46,7 +46,10 @@ try {
 }
 ---
 
-<div class="w-full">
+<style is:global>
+  html, body { overflow: hidden; height: 100%; }
+</style>
+<div class="flex w-full flex-1 items-center overflow-hidden">
   <FlippableProfileCard
     client:load
     {...profile}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,10 +4,12 @@ import Header from "../components/shared/Header.astro";
 
 interface Props {
   title?: string;
+  flush?: boolean;
 }
 
 const {
   title = "ATmosphereConf • Global ATProto Community Conference • Vancouver, Canada, March 26th - 29th, 2026",
+  flush = false,
 } = Astro.props;
 ---
 
@@ -41,7 +43,7 @@ const {
     <div class="flex min-h-screen flex-col">
       <Header transition:animate="none" />
       <main
-        class="mx-auto mb-10 flex w-full max-w-4xl flex-1 flex-col px-2 sm:px-10"
+        class={`mx-auto flex w-full max-w-4xl flex-1 flex-col px-2 sm:px-10 ${flush ? "" : "mb-10"}`}
       >
         <slot />
       </main>

--- a/src/pages/profile/[handle].astro
+++ b/src/pages/profile/[handle].astro
@@ -32,6 +32,6 @@ const editData = isOwnProfile
   : undefined;
 ---
 
-<Layout title={`${profile.displayName} - Atmosphere Conference`}>
+<Layout title={`${profile.displayName} - Atmosphere Conference`} flush>
   <ProfilePage {profile} {editData} {viewerDid} {viewerHandle} />
 </Layout>


### PR DESCRIPTION
## overview

followup to on 2 bugs that came from [feat: add feed and theme to profile card #43](https://github.com/ATProtocol-Community/atmosphereconf/pull/43) 

## description

fixes 2 bugs from above PR:
- drag handle on front face card
- visual bug where scroll bars would show when they didnt need to

visual bug came from `mb-10` on layout component. this is needed for the main page to give some breathing room at teh bottom, however was clashing for profile layout where there's a vertically centered and responsive card.

i took the liberty to add a max-height `78dvh` (looked right to me) on the profile card so the view can stay responsive. the tradeoff is the theres a scroll inside the card instead of outside the card (big cards on normal screen or all cards on small screens w/out max-height will cause scroll regardless so dedcided to keep a visual consistency throughout all card data lengths


## screen grabs

https://github.com/user-attachments/assets/90d0d047-e765-42f4-9794-dafe57919693


