### PR TITLE
fix: bring back min height

### DIFF
--- a/src/components/profile/FlippableProfileCard.tsx
+++ b/src/components/profile/FlippableProfileCard.tsx
@@ -157,7 +157,7 @@ export function FlippableProfileCard({
       <div className="mx-auto my-auto max-w-2xl" data-theme={theme}>
         {!flipped ? (
           <div
-            className={`bg-card text-card-foreground relative flex max-h-[85dvh] max-h-[78dvh] sm:max-h-[85dvh] flex-col overflow-auto ${cardClasses}`}
+            className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col justify-center overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
           >
             {frontFaceContent}
           </div>
@@ -190,7 +190,7 @@ export function FlippableProfileCard({
       >
         {/* Front face — conference profile */}
         <div
-          className={`bg-card text-card-foreground relative flex max-h-[78dvh] sm:max-h-[85dvh] flex-col overflow-auto ${cardClasses}`}
+          className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col justify-center overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
           style={{
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",


### PR DESCRIPTION
## description

fixes visual bug for user's with not a lot of profiile data

sets a min height so the card is usable

### before
<img width="810" height="933" alt="Screenshot 2026-03-13 at 7 37 06 AM" src="https://github.com/user-attachments/assets/8056c421-013a-4f17-bb3d-9d0216e7034a" />
<img width="750" height="930" alt="Screenshot 2026-03-13 at 7 37 48 AM" src="https://github.com/user-attachments/assets/5e32158b-a42c-4f06-b54b-12f7f6ab213c" />


### after

<img width="728" height="935" alt="Screenshot 2026-03-13 at 7 38 04 AM" src="https://github.com/user-attachments/assets/7c2b4d03-552e-434c-9db0-46e669df9518" />
<img width="649" height="924" alt="Screenshot 2026-03-13 at 7 38 16 AM" src="https://github.com/user-attachments/assets/434d1c74-7fe5-4236-8c04-3d8313282b27" />
