### PR TITLE
fix: add buffer btwn profile avatar y theme cta

### DIFF
--- a/src/components/profile/FlippableProfileCard.tsx
+++ b/src/components/profile/FlippableProfileCard.tsx
@@ -132,22 +132,24 @@ export function FlippableProfileCard({
           </button>
         )}
       </div>
-      <div className="pt-6" />
-      <div {...dragHandleProps}>
-        <ProfileView {...profileProps} />
-      </div>
-      {talks.length > 0 && (
-        <div className="mt-4">
-          <div className="text-muted-foreground mb-2 text-xs tracking-wide uppercase">
-            Talk
-          </div>
-          <div className="flex flex-col gap-2">
-            {talks.map((talk) => (
-              <TalkCard key={talk.id} talk={talk} />
-            ))}
-          </div>
+      <div className="my-auto">
+        <div className="pt-6" />
+        <div {...dragHandleProps}>
+          <ProfileView {...profileProps} />
         </div>
-      )}
+        {talks.length > 0 && (
+          <div className="mt-4">
+            <div className="text-muted-foreground mb-2 text-xs tracking-wide uppercase">
+              Talk
+            </div>
+            <div className="flex flex-col gap-2">
+              {talks.map((talk) => (
+                <TalkCard key={talk.id} talk={talk} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </>
   );
 
@@ -157,7 +159,7 @@ export function FlippableProfileCard({
       <div className="mx-auto my-auto max-w-2xl" data-theme={theme}>
         {!flipped ? (
           <div
-            className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col justify-center overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
+            className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
           >
             {frontFaceContent}
           </div>
@@ -190,7 +192,7 @@ export function FlippableProfileCard({
       >
         {/* Front face — conference profile */}
         <div
-          className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col justify-center overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
+          className={`bg-card text-card-foreground relative flex max-h-[78dvh] flex-col overflow-auto sm:max-h-[85dvh] sm:min-h-[75dvh] ${cardClasses}`}
           style={{
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",


### PR DESCRIPTION

## description

when fixing small profile cards i centered teh conference profile vertically but didnt account for the theme button and avatar clashing on large profiles 👎 

so, instead of using `justify-center` within the front face card components ive added auto margin at the parent to include a centered buffer between the theme button and profile itself throughout. that way small profiles stay centered while the larger ones get enough room


too many followups with this one so had to make sure this time with _every_ speaker!

## screengrabs
### before

<img width="1727" height="986" alt="Screenshot 2026-03-13 at 5 31 56 PM" src="https://github.com/user-attachments/assets/9b130fb5-6bdd-4953-b242-e455201070b3" />


### after

#### front
https://github.com/user-attachments/assets/c734c819-c028-46f4-8578-41783a33c0e2

#### back (3 batches bc it was too large)

https://github.com/user-attachments/assets/ed476eee-9eef-4d42-b595-cae62f9b91eb

https://github.com/user-attachments/assets/13efa3ff-9635-4a16-a50a-9af760bd2eab

https://github.com/user-attachments/assets/a5ace213-6c90-4e0a-8a69-d26808be12ee

