### PR TITLE
fix: update pckt theme to match brand

### DIFF
--- a/src/components/home/TicketStubLink.astro
+++ b/src/components/home/TicketStubLink.astro
@@ -29,8 +29,8 @@ const { href = "#tickets" } = Astro.props;
   }
 
   .ticket-tab {
-    background: var(--primary);
-    color: var(--primary-foreground);
+    background: var(--ticket-tab-bg, var(--primary));
+    color: var(--ticket-tab-fg, var(--primary-foreground));
     padding: 0.85rem 0.85rem;
     font-family: var(--font-mono), ui-monospace, monospace;
     font-size: 0.7rem;
@@ -69,8 +69,12 @@ const { href = "#tickets" } = Astro.props;
   }
 
   .ticket-body {
-    background: color-mix(in oklch, var(--primary), transparent 92%);
-    border: 2px dashed color-mix(in oklch, var(--primary), transparent 70%);
+    background: var(
+      --ticket-body-bg,
+      color-mix(in oklch, var(--primary), transparent 92%)
+    );
+    border: 2px dashed
+      var(--ticket-border, color-mix(in oklch, var(--primary), transparent 70%));
     border-left: none;
     padding: 0.85rem 1.5rem;
     display: flex;
@@ -82,7 +86,7 @@ const { href = "#tickets" } = Astro.props;
   .ticket-label {
     font-family: var(--font-mono), ui-monospace, monospace;
     font-size: 0.65rem;
-    color: var(--primary);
+    color: var(--ticket-label, var(--primary));
     text-transform: uppercase;
     letter-spacing: 0.15em;
     font-weight: 600;
@@ -91,7 +95,7 @@ const { href = "#tickets" } = Astro.props;
   .ticket-main {
     font-size: 1.3rem;
     font-weight: 700;
-    color: var(--foreground);
+    color: var(--ticket-main, var(--foreground));
   }
 
   .ticket-arrow {

--- a/src/components/shared/HeaderTicket.astro
+++ b/src/components/shared/HeaderTicket.astro
@@ -73,8 +73,8 @@
   }
 
   .ntp-tab {
-    background: var(--primary);
-    color: var(--primary-foreground);
+    background: var(--ticket-tab-bg, var(--primary));
+    color: var(--ticket-tab-fg, var(--primary-foreground));
     padding: 0.6rem 0.4rem;
     font-size: 0.45rem;
     font-weight: 700;
@@ -110,8 +110,9 @@
     z-index: 1;
   }
   .ntp-body {
-    background: var(--card);
-    border: 2px dashed color-mix(in oklch, var(--primary), transparent 70%);
+    background: var(--ticket-body-bg, var(--card));
+    border: 2px dashed
+      var(--ticket-border, color-mix(in oklch, var(--primary), transparent 70%));
     border-left: none;
     border-top: none;
     padding: 0.6rem 1rem;
@@ -124,13 +125,13 @@
     font-size: 0.5rem;
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    color: var(--primary);
+    color: var(--ticket-label, var(--primary));
     font-weight: 600;
   }
   .ntp-main {
     font-size: 0.85rem;
     font-weight: 700;
-    color: var(--foreground);
+    color: var(--ticket-main, var(--foreground));
     white-space: nowrap;
   }
 
@@ -153,8 +154,8 @@
   }
 
   .ntt-tab {
-    background: var(--primary);
-    color: var(--primary-foreground);
+    background: var(--ticket-tab-bg, var(--primary));
+    color: var(--ticket-tab-fg, var(--primary-foreground));
     padding: 0 0.45rem;
     font-size: 0.4rem;
     font-weight: 700;
@@ -192,8 +193,9 @@
   }
   .ntt-body {
     flex: 1;
-    background: var(--card);
-    border: 2px dashed color-mix(in oklch, var(--primary), transparent 70%);
+    background: var(--ticket-body-bg, var(--card));
+    border: 2px dashed
+      var(--ticket-border, color-mix(in oklch, var(--primary), transparent 70%));
     border-left: none;
     height: 40px;
     overflow: hidden;
@@ -219,12 +221,12 @@
   .ntt-cta {
     font-size: 0.7rem;
     font-weight: 700;
-    color: var(--foreground);
+    color: var(--ticket-main, var(--foreground));
   }
   .ntt-detail {
     font-size: 0.6rem;
     font-weight: 600;
-    color: var(--primary);
+    color: var(--ticket-label, var(--primary));
     text-transform: uppercase;
     letter-spacing: 0.08em;
   }

--- a/src/components/ui/DaySchedule.astro
+++ b/src/components/ui/DaySchedule.astro
@@ -164,7 +164,7 @@ const timeGridRows = `grid-template-rows: 0.5rem repeat(${totalSlots}, 3rem)`;
   <!-- ========== DESKTOP: Full multi-column layout ========== -->
   <div class="hidden overflow-x-auto md:block">
     <div style={`min-width: ${rooms.length * 10 + 4}rem`}>
-      <div class="border-border bg-card flex border-b">
+      <div class="border-border bg-card flex overflow-hidden rounded-t-lg border-b">
         <div class="border-border w-14 flex-none border-r"></div>
         <div
           class="divide-border grid flex-auto divide-x"

--- a/src/styles/themes/pckt.css
+++ b/src/styles/themes/pckt.css
@@ -1,67 +1,83 @@
 [data-theme="pckt"] {
-  /* Palette — sourced from pckt.blog */
-  --theme-bg: oklch(0.145 0.02 260);
-  --theme-fg: oklch(0.984 0.005 260);
-  --theme-muted: oklch(0.65 0.02 260);
-  --theme-accent: oklch(0.723 0.219 149.579);
-  --theme-surface: oklch(0.208 0.03 260);
-  --theme-border: oklch(0.723 0.219 149.579 / 0.25);
+  /* Palette — pckt logo: red p, blue c, green k/t */
+  --pckt-red: #FF5D5B;
+  --pckt-blue: #58A7FF;
+  --pckt-yellow: #FFCA46;
+  --pckt-green: #21DC66;
+
+  /* Light theme — white bg, warm beige cards, red borders */
+  --theme-bg: oklch(0.96 0.015 60);
+  --theme-fg: oklch(0.20 0.02 85);
+  --theme-muted: oklch(0.55 0.02 85);
+  --theme-accent: var(--pckt-red);
+  --theme-surface: oklch(0.99 0.002 85);
+  --theme-border: var(--pckt-red);
 
   /* Full semantic overrides */
   --background: var(--theme-bg);
   --foreground: var(--theme-fg);
   --card: var(--theme-surface);
   --card-foreground: var(--theme-fg);
-  --popover: var(--theme-surface);
+  --popover: oklch(0.98 0.01 60);
   --popover-foreground: var(--theme-fg);
-  --primary: var(--theme-accent);
-  --primary-foreground: oklch(0.208 0.03 260);
-  --secondary: oklch(0.279 0.03 260);
+  --primary: var(--pckt-blue);
+  --primary-foreground: oklch(0.98 0.01 85);
+  --secondary: oklch(0.93 0.02 60);
   --secondary-foreground: var(--theme-fg);
-  --muted: var(--theme-surface);
+  --muted: oklch(0.93 0.02 60);
   --muted-foreground: var(--theme-muted);
-  --accent: oklch(0.279 0.03 260);
+  --accent: oklch(0.93 0.02 60);
   --accent-foreground: var(--theme-fg);
   --border: var(--theme-border);
-  --input: oklch(0.372 0.03 260 / 0.3);
-  --ring: var(--theme-accent);
+  --input: oklch(0.20 0.02 85 / 0.08);
+  --ring: var(--pckt-blue);
 
-  /* Header */
-  --header-bg: oklch(0.129 0.02 260);
-  --header-fg: var(--theme-fg);
-  --header-fg-muted: oklch(0.704 0.015 260 / 0.8);
-  --header-border: oklch(0.723 0.219 149.579 / 0.3);
-  --header-logo-accent: var(--theme-accent);
+  /* Header — yellow bg, red text, blue AT */
+  --header-bg: var(--pckt-yellow);
+  --header-fg: var(--pckt-red);
+  --header-fg-muted: oklch(0.35 0.03 60);
+  --header-border: var(--pckt-red);
+  --header-logo-accent: var(--pckt-blue);
 
-  /* atproto profile tokens */
+  /* atproto profile — Mondrian color blocks */
   --atproto-profile-bg: var(--theme-bg);
   --atproto-profile-banner: linear-gradient(
     to right,
-    oklch(0.208 0.03 260),
-    oklch(0.279 0.03 260)
+    var(--pckt-blue) 0%, var(--pckt-blue) 25%,
+    var(--pckt-red) 25%, var(--pckt-red) 45%,
+    var(--pckt-green) 45%, var(--pckt-green) 65%,
+    var(--pckt-yellow) 65%, var(--pckt-yellow) 100%
   );
-  --atproto-profile-ring: var(--theme-bg);
-  --atproto-profile-pill-bg: oklch(0.145 0.02 260 / 0.85);
-  --atproto-profile-pill-fg: var(--theme-accent);
-  --atproto-profile-link: var(--theme-accent);
+  --atproto-profile-ring: var(--pckt-green);
+  --atproto-profile-pill-bg: oklch(0.88 0.08 150);
+  --atproto-profile-pill-fg: oklch(0.35 0.10 150);
+  --atproto-profile-link: var(--pckt-blue);
 
-  /* Event-type badges — pckt logo colors: blue, yellow, red (no green — blends with bg) */
-  --event-presentation-bg: oklch(0.546 0.245 262.881 / 0.2);
-  --event-presentation-fg: oklch(0.707 0.165 254.624);
-  --event-presentation-sub: oklch(0.546 0.245 262.881);
-  --event-lightning-bg: oklch(0.795 0.184 86.047 / 0.15);
-  --event-lightning-fg: oklch(0.905 0.182 98.111);
-  --event-lightning-sub: oklch(0.681 0.162 75.834);
-  --event-panel-bg: oklch(0.637 0.237 25.331 / 0.18);
-  --event-panel-fg: oklch(0.704 0.191 22.216);
-  --event-panel-sub: oklch(0.577 0.245 27.325);
-  --event-workshop-bg: oklch(0.637 0.237 25.331 / 0.18);
-  --event-workshop-fg: oklch(0.704 0.191 22.216);
-  --event-workshop-sub: oklch(0.577 0.245 27.325);
-  --event-info-bg: oklch(0.795 0.184 86.047 / 0.12);
-  --event-info-fg: oklch(0.905 0.182 98.111);
-  --event-info-sub: oklch(0.681 0.162 75.834);
-  --event-activity-bg: oklch(0.723 0.219 149.579 / 0.15);
-  --event-activity-fg: oklch(0.792 0.209 151.711);
-  --event-activity-sub: oklch(0.627 0.194 149.214);
+  /* Ticket stub — all blue-toned */
+  --ticket-tab-bg: var(--pckt-blue);
+  --ticket-tab-fg: oklch(0.97 0.01 85);
+  --ticket-body-bg: oklch(0.95 0.02 262);
+  --ticket-border: oklch(0.82 0.06 262);
+  --ticket-label: var(--pckt-blue);
+  --ticket-main: var(--theme-fg);
+
+  /* Event badges — all four logo colors, more opaque to cover red grid lines */
+  --event-presentation-bg: oklch(0.88 0.08 262);
+  --event-presentation-fg: oklch(0.35 0.15 262);
+  --event-presentation-sub: oklch(0.35 0.15 262);
+  --event-lightning-bg: oklch(0.92 0.08 85);
+  --event-lightning-fg: oklch(0.45 0.12 85);
+  --event-lightning-sub: oklch(0.45 0.12 85);
+  --event-panel-bg: oklch(0.88 0.08 27);
+  --event-panel-fg: oklch(0.35 0.15 27);
+  --event-panel-sub: oklch(0.35 0.15 27);
+  --event-workshop-bg: oklch(0.88 0.08 150);
+  --event-workshop-fg: oklch(0.35 0.13 150);
+  --event-workshop-sub: oklch(0.35 0.13 150);
+  --event-info-bg: oklch(0.90 0.06 262);
+  --event-info-fg: oklch(0.35 0.15 262);
+  --event-info-sub: oklch(0.35 0.15 262);
+  --event-activity-bg: oklch(0.93 0.06 85);
+  --event-activity-fg: oklch(0.45 0.12 85);
+  --event-activity-sub: oklch(0.45 0.12 85);
 }


### PR DESCRIPTION
## description

this PR is a follow up to #50 - theming the full site - to update the pckt theme to mach their branding

- mostly just edits to pckt theme css
- adds bg to tickets (both header and main)

### screengrab of new theme


https://github.com/user-attachments/assets/79bd85d2-7cfb-4c9d-9e1f-2e8cbfeff144


https://github.com/user-attachments/assets/d1be8c0b-48cd-4a9f-964f-e875778a341a




### unrelated
- fixes rounded corners on calendar where they didnt touch before
### before
<img width="75" height="47" alt="broken-corner" src="https://github.com/user-attachments/assets/3e1d6c67-54e6-4542-94d6-bd48b469a23d" />

### after

<img width="70" height="61" alt="connected-corner" src="https://github.com/user-attachments/assets/04fb9a14-3d25-44b3-ad8e-20c821220a5b" />
