### PR TITLE
feat: interactive transcripts on event pages

### DIFF
--- a/src/components/InteractiveTranscript.astro
+++ b/src/components/InteractiveTranscript.astro
@@ -1,0 +1,391 @@
+---
+interface Props {
+  uid: string;
+  transcriptHtml: string;
+  playerSelector?: string;
+}
+
+const { uid, transcriptHtml, playerSelector = ".vod-video" } = Astro.props;
+// Plain `clip` is intentional: each event page has at most one transcript,
+// so namespacing the DOM id by slug just makes share URLs uglier — HAL
+// derives the hash-fragment prefix from `transcript.id`, so this becomes
+// `#clip=START,END`.
+const transcriptId = "clip";
+---
+
+<div
+  class="interactive-transcript"
+  data-uid={uid}
+  data-player-selector={playerSelector}
+>
+  <div
+    id={transcriptId}
+    class="hyperaudio-transcript"
+    set:html={transcriptHtml}
+  />
+  <div class="share-popover" hidden>
+    <button class="share-popover-btn" type="button" data-mode="link">
+      <span class="label-default">Copy link</span>
+      <span class="label-copied" hidden>Copied</span>
+    </button>
+    <button class="share-popover-btn" type="button" data-mode="quote">
+      <span class="label-default">Copy with quote</span>
+      <span class="label-copied" hidden>Copied</span>
+    </button>
+  </div>
+</div>
+
+<script>
+  import { HyperaudioLite } from "@/lib/hyperaudio-lite.js";
+  import { caption } from "@/lib/caption.js";
+
+  document
+    .querySelectorAll<HTMLElement>(".interactive-transcript")
+    .forEach((container) => {
+      const uid = container.dataset.uid!;
+      const playerSelector = container.dataset.playerSelector || ".vod-video";
+      // Must match the DOM id set in the Astro frontmatter — share URLs
+      // derive their hash fragment from this (`#clip=START,END`).
+      const transcriptId = "clip";
+      const playerId = `hyperplayer-${uid}`;
+
+      // HAL needs an id on the video element; find the sibling player and
+      // assign one. Walking to the parent first scopes the search so multiple
+      // talks on a page don't cross-wire.
+      const scope = container.parentElement ?? document;
+      const video = scope.querySelector<HTMLVideoElement>(playerSelector);
+      if (!video) return;
+      if (!video.id) video.id = playerId;
+
+      // (transcriptId, playerId, minimised, autoscroll, doubleClick, webMonetization, playOnClick)
+      const hal = new HyperaudioLite(
+        transcriptId,
+        video.id,
+        false,
+        true,
+        false,
+        false,
+        true,
+      );
+
+      // HAL's poll loop only runs while playing, so scrubbing the player
+      // while paused doesn't update the highlight on its own. Bridge it —
+      // and HAL also skips word-level .active when paused, so reapply it
+      // ourselves using the index it returns.
+      video.addEventListener("seeked", () => {
+        if (!video.paused) return;
+        const { currentWordIndex } = hal.updateTranscriptVisualState(
+          video.currentTime,
+        );
+        if (currentWordIndex > 0 && hal.wordArr[currentWordIndex - 1]) {
+          hal.wordArr[currentWordIndex - 1].n.classList.add("active");
+        }
+      });
+
+      // Attach a <track> to the video so HAL's caption.js has somewhere to
+      // write its generated VTT. caption.js looks up the track by id (the
+      // convention is `${playerId}-vtt`) and sets its src to a data: URL
+      // once the video fires loadedmetadata.
+      const trackId = `${video.id}-vtt`;
+      if (!document.getElementById(trackId)) {
+        const trackEl = document.createElement("track");
+        trackEl.id = trackId;
+        trackEl.kind = "captions";
+        trackEl.label = "English";
+        trackEl.srclang = "en";
+        trackEl.default = true;
+        video.appendChild(trackEl);
+      }
+      caption().init(transcriptId, video.id, undefined, undefined, "English", "en");
+
+      // --- Deeplink receive: hash like
+      //     #hypertranscript-{slug}=4.40,12.60
+      // HAL parses it and positions the transcript visually, but does NOT
+      // seek the player. Seek the underlying video ourselves so a shared
+      // link starts playback at the right time once the user hits play.
+      const initialStart = parseFloat(hal.hashArray?.[0]);
+      if (!isNaN(initialStart)) {
+        const applyStart = () => {
+          video.currentTime = initialStart;
+        };
+        if (video.readyState >= 1) {
+          applyStart();
+        } else {
+          video.addEventListener("loadedmetadata", applyStart, { once: true });
+        }
+      }
+
+      // --- Deeplink send: surface a popover with two copy actions when the
+      // user finishes selecting text inside the transcript. HAL's
+      // getSelectionMediaFragment() does the time-range math; we wrap a
+      // small UI around it.
+      const popover = container.querySelector<HTMLElement>(".share-popover");
+      const popoverBtns = popover
+        ? Array.from(
+            popover.querySelectorAll<HTMLButtonElement>(".share-popover-btn"),
+          )
+        : [];
+
+      const resetButtonLabel = (btn: HTMLButtonElement) => {
+        const def = btn.querySelector<HTMLElement>(".label-default");
+        const cop = btn.querySelector<HTMLElement>(".label-copied");
+        if (def) def.hidden = false;
+        if (cop) cop.hidden = true;
+      };
+      const showCopiedLabel = (btn: HTMLButtonElement) => {
+        const def = btn.querySelector<HTMLElement>(".label-default");
+        const cop = btn.querySelector<HTMLElement>(".label-copied");
+        if (def) def.hidden = true;
+        if (cop) cop.hidden = false;
+      };
+
+      const hideSharePopover = () => {
+        if (!popover) return;
+        popover.hidden = true;
+        popoverBtns.forEach(resetButtonLabel);
+      };
+
+      const positionSharePopover = (rect: DOMRect) => {
+        if (!popover) return;
+        // Show first so we can measure offsetWidth.
+        popover.hidden = false;
+        const containerRect = container.getBoundingClientRect();
+        const top = rect.bottom - containerRect.top + 6;
+        const left = Math.min(
+          rect.left - containerRect.left,
+          container.clientWidth - popover.offsetWidth - 12,
+        );
+        popover.style.top = `${top}px`;
+        popover.style.left = `${Math.max(left, 8)}px`;
+      };
+
+      const transcriptEl = document.getElementById(transcriptId);
+
+      // Show only AFTER selection is complete — selectionchange fires
+      // mid-drag, so reacting to it would make the popover flicker.
+      const showIfValidSelection = () => {
+        const selection = window.getSelection();
+        if (!selection || selection.isCollapsed) {
+          hideSharePopover();
+          return;
+        }
+        const range = selection.getRangeAt(0);
+        if (
+          !transcriptEl ||
+          !transcriptEl.contains(range.commonAncestorContainer)
+        ) {
+          hideSharePopover();
+          return;
+        }
+        positionSharePopover(range.getBoundingClientRect());
+      };
+      document.addEventListener("mouseup", showIfValidSelection);
+      document.addEventListener("touchend", showIfValidSelection);
+
+      // Hide as soon as the selection collapses (e.g. user clicks elsewhere).
+      document.addEventListener("selectionchange", () => {
+        const selection = window.getSelection();
+        if (!selection || selection.isCollapsed) hideSharePopover();
+      });
+
+      // Track the selection while the transcript (or the page) scrolls so
+      // the popover stays anchored to the selected text. Hide while the
+      // selection is scrolled outside the visible transcript pane; re-show
+      // when it comes back. rAF-throttled because `scroll` fires a lot.
+      let scrollRafId = 0;
+      const repositionOrHideOnScroll = () => {
+        const selection = window.getSelection();
+        if (!selection || selection.isCollapsed) return;
+        const range = selection.getRangeAt(0);
+        if (!transcriptEl?.contains(range.commonAncestorContainer)) return;
+
+        const rect = range.getBoundingClientRect();
+        const tRect = transcriptEl.getBoundingClientRect();
+        if (rect.bottom < tRect.top || rect.top > tRect.bottom) {
+          if (popover && !popover.hidden) {
+            popover.hidden = true;
+            popoverBtns.forEach(resetButtonLabel);
+          }
+        } else {
+          positionSharePopover(rect);
+        }
+      };
+      const onScroll = () => {
+        if (scrollRafId) return;
+        scrollRafId = requestAnimationFrame(() => {
+          scrollRafId = 0;
+          repositionOrHideOnScroll();
+        });
+      };
+      document.addEventListener("scroll", onScroll, true);
+
+      const copyToClipboard = async (text: string, btn: HTMLButtonElement) => {
+        try {
+          await navigator.clipboard.writeText(text);
+          showCopiedLabel(btn);
+          setTimeout(hideSharePopover, 1500);
+        } catch {
+          // Clipboard API not available; fall back to writing the hash to
+          // the URL bar so the user can copy it themselves.
+          const fragment = hal.getSelectionMediaFragment();
+          if (fragment) location.hash = fragment;
+        }
+      };
+
+      popoverBtns.forEach((btn) => {
+        // mousedown.preventDefault keeps the document selection alive when
+        // the user clicks the button — otherwise focus shifts and the
+        // selection collapses before our click handler runs.
+        btn.addEventListener("mousedown", (e) => e.preventDefault());
+
+        btn.addEventListener("click", async () => {
+          const fragment = hal.getSelectionMediaFragment();
+          if (!fragment) return;
+          const url = `${location.origin}${location.pathname}#${fragment}`;
+
+          if (btn.dataset.mode === "quote") {
+            const selectedText =
+              window.getSelection()?.toString().trim().replace(/\s+/g, " ") ??
+              "";
+            const payload = selectedText
+              ? `"${selectedText}"\n\n${url}`
+              : url;
+            await copyToClipboard(payload, btn);
+          } else {
+            await copyToClipboard(url, btn);
+          }
+        });
+      });
+    });
+</script>
+
+<style>
+  .interactive-transcript {
+    position: relative;
+    margin-top: 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg, 0.75rem);
+    background: var(--card, transparent);
+  }
+
+  .hyperaudio-transcript {
+    max-height: 24rem;
+    overflow-y: auto;
+    padding: 1rem 1.25rem;
+    line-height: 1.7;
+    color: var(--foreground);
+    font-size: 0.95rem;
+  }
+
+  .hyperaudio-transcript :global(p) {
+    margin: 0 0 0.85em 0;
+  }
+
+  .hyperaudio-transcript :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  /* Speaker label at the start of paragraphs that have one. Omitted from
+     the rendered HTML entirely for paragraphs without a speaker. */
+  .hyperaudio-transcript :global(.speaker) {
+    display: inline;
+    margin-right: 0.4em;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--muted-foreground);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .hyperaudio-transcript :global(span) {
+    cursor: pointer;
+    transition:
+      color 120ms ease,
+      background-color 80ms ease;
+    border-radius: 2px;
+    /* Default before HAL applies .read / .unread — match the .unread tone
+       so the initial paint matches the "not yet played" state. */
+    color: var(--muted-foreground);
+  }
+
+  /* Words already played: full foreground contrast. */
+  .hyperaudio-transcript :global(span.read) {
+    color: var(--foreground);
+  }
+
+  /* Words not yet played: lighter. */
+  .hyperaudio-transcript :global(span.unread) {
+    color: var(--muted-foreground);
+  }
+
+  .hyperaudio-transcript :global(span:hover) {
+    background: color-mix(in oklch, var(--accent), transparent 85%);
+  }
+
+  /* Active word: underline, slight accent tint. Underline (not bold) so the
+     line height and word widths stay stable as the highlight advances. */
+  .hyperaudio-transcript :global(.active > .active) {
+    color: var(--foreground);
+    background: color-mix(in oklch, var(--accent), transparent 75%);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+  }
+
+  /* Words inside a deeplinked range (#clip=start,end). HAL applies
+     .share-match to every span in the range when the page loads with a hash
+     fragment. Reuses the workshop-event color tokens (a muted green
+     theme-aware pair) so it stays distinct from .active (accent-tinted) and
+     adapts to dark themes. */
+  .hyperaudio-transcript :global(span.share-match) {
+    background: var(--event-workshop-bg);
+    color: var(--event-workshop-fg);
+  }
+
+  .share-popover {
+    position: absolute;
+    z-index: 5;
+    display: inline-flex;
+    gap: 0.35rem;
+    padding: 0.3rem;
+    background: var(--card, var(--background, #fff));
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .share-popover-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.8rem;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1;
+    color: #fff;
+    background: #3e97ff;
+    border: 1px solid #3e97ff;
+    border-radius: 999px;
+    cursor: pointer;
+    transition:
+      transform 100ms ease,
+      background-color 80ms ease,
+      border-color 80ms ease;
+  }
+
+  .share-popover-btn:hover {
+    background: #2d83e6;
+    border-color: #2d83e6;
+  }
+
+  .share-popover-btn:active {
+    transform: translateY(1px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hyperaudio-transcript :global(span),
+    .share-popover-btn {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/ui/VodPlayer.astro
+++ b/src/components/ui/VodPlayer.astro
@@ -69,14 +69,18 @@ const playlistUrl = `${VOD_PLAYBACK_BASE}?uri=${encodeURIComponent(vodAtUri)}`;
           "current-time",
           "mute",
           "volume",
+          "captions",
           "settings",
           "fullscreen",
         ],
-        settings: ["speed"],
+        settings: ["captions", "speed"],
         speed: {
           selected: 1,
           options: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
         },
+        // `update: true` makes Plyr re-detect <track> elements added after
+        // init — InteractiveTranscript appends the captions track post-hoc.
+        captions: { active: true, language: "auto", update: true },
         ratio: "16:9",
       });
 

--- a/src/content/transcripts/README.md
+++ b/src/content/transcripts/README.md
@@ -1,0 +1,226 @@
+# Interactive transcripts
+
+When a file matching `src/content/transcripts/{event-slug}.json` exists, the
+event page at `/event/{slug}` renders an interactive transcript pane below the
+video and turns on captions in the Plyr player. Clicking a word seeks playback;
+scrubbing the player advances the highlighted word. Talks without a transcript
+file render exactly as before.
+
+This feature is built on
+[Hyperaudio Lite (HAL)](https://github.com/hyperaudio/hyperaudio-lite) —
+a small open-source JavaScript library for word-level interactive transcripts.
+HAL is referenced throughout the rest of this document.
+
+## Transcript JSON format
+
+Each transcript is a JSON file in this shape:
+
+```json
+{
+  "words": [
+    { "start": 1.44, "end": 2.00, "text": "Hello" },
+    { "start": 2.00, "end": 2.30, "text": "world." }
+  ],
+  "paragraphs": [
+    { "start": 1.44, "end": 2.30, "speaker": "SPEAKER_S1" }
+  ]
+}
+```
+
+- `words[]` — every word, in order. `start` and `end` are seconds (decimal).
+  `text` is the word as it should render; punctuation stays attached, but
+  surrounding whitespace is trimmed.
+- `paragraphs[]` — paragraph boundaries with optional `speaker`. Each word is
+  placed in the first paragraph whose `[start, end]` range contains it.
+  Words that fall outside every paragraph are dropped with a build-time warning.
+- `speaker` is optional per paragraph. When present it renders as a small
+  bold inline label at the start of the paragraph; when absent, the paragraph
+  renders normally with no label. Speaker IDs are free-form strings — use
+  `SPEAKER_S1` / `SPEAKER_S2` placeholders, real names, or AT handles, your
+  call.
+
+The JSON is the canonical storage format. At SSR, `src/lib/transcript-json.ts`
+converts it to HAL-compatible HTML (paragraphs of `<span data-m data-d>` word
+spans) and the component injects that via `set:html`. We keep JSON because
+it's portable to AT Proto records, [Standard.site](https://standard.site)
+renderers, and any future tooling — see Phase 2 in the main brief.
+
+## Adding a transcript for a talk
+
+1. Produce the JSON for the talk. Word-timed JSON is what most speech-to-text
+   services (Whisper, Deepgram, AssemblyAI, etc.) return natively; the
+   Hyperaudio Lite Editor will also gain a JSON export. The shape only needs
+   to match the schema above.
+2. Save as `src/content/transcripts/{event-slug}.json`. The slug is the `id`
+   segment from the event URL — e.g. `rjQ96kl` for `/event/rjQ96kl`.
+3. `npm run dev` and open `/event/{slug}` to confirm the transcript renders
+   and tracks playback.
+
+See `rjQ96kl.json` for a worked example.
+
+## Architecture
+
+Four pieces work together:
+
+- **`src/lib/transcript-json.ts`** — TypeScript types for the JSON shape plus
+  the SSR helper that converts JSON to HAL-compatible HTML.
+- **`src/components/InteractiveTranscript.astro`** — renders the transcript
+  pane and wires up HAL + caption.js on the client. It does not own the video
+  element; it finds the sibling `<video class="vod-video">` rendered by
+  `VodPlayer` and operates on it directly.
+- **`src/pages/event/[id].astro`** — discovers transcript files with
+  `import.meta.glob('*.json')`, runs `transcriptJsonToHtml()` on a match, and
+  conditionally renders `<InteractiveTranscript>` with the resulting HTML.
+- **`src/components/ui/VodPlayer.astro`** — unchanged structurally; Plyr's
+  config gained captions controls and `update: true` so it picks up the
+  `<track>` element that InteractiveTranscript injects.
+
+The transcript JSON files are imported at build time and inlined into the SSR
+output. They are not Astro content-collection entries (no schema), they just
+live under `src/content/` alongside other build-time data.
+
+## How playback sync works
+
+The HAL runtime (`src/lib/hyperaudio-lite.js`) does two things:
+
+1. **Word-click → seek.** Clicking a `<span data-m="...">` calls
+   `video.currentTime = data-m / 1000` and `video.play()` (because
+   `playOnClick=true` is passed to the constructor). Plyr's UI listens to
+   `timeupdate` / `play` on the underlying `<video>` and updates accordingly.
+
+2. **Playback → highlight.** When the video is playing, HAL runs a
+   self-driven `setTimeout` loop that re-reads `video.currentTime` each tick
+   and applies the `.active` class to the matching word and its parent
+   paragraph.
+
+Words HAL has passed get a `.read` class; words still ahead get `.unread`.
+Styling is in `InteractiveTranscript.astro`:
+
+- `.read` → full `--foreground` contrast
+- `.unread` → muted `--muted-foreground`
+- `.active > .active` → accent-tinted underline (no bold — avoids
+  width-instability layout shift as the highlight advances)
+
+## Two workarounds in the wiring
+
+These are non-obvious behaviors in HAL v2.4.2 that the component bridges in
+the JS layer (no upstream changes needed):
+
+1. **HAL stops polling when paused.** It listens for `play`/`pause` on the
+   video but not for `seeked`. If the user scrubs Plyr while the video is
+   paused, HAL doesn't notice the new time. The component adds a `seeked`
+   listener that calls `hal.updateTranscriptVisualState(currentTime)` to
+   manually refresh.
+
+2. **HAL skips word-level `.active` when paused.** Internally,
+   `updateTranscriptVisualState` only adds `.active` to the current word
+   if `myPlayer.paused === false`. The parent paragraph still gets `.active`,
+   but our CSS only highlights the inner word — so without intervention,
+   scrubbing while paused would visually do nothing. The component reads the
+   `currentWordIndex` from the returned object and reapplies `.active` to the
+   correct `wordArr[index - 1].n` itself.
+
+Both workarounds live next to the HAL constructor call in
+`InteractiveTranscript.astro` and total ~10 lines.
+
+## Deeplinks
+
+The component supports word-range deeplinks of the form
+`/event/{slug}#clip=START,END`, where `START` and `END` are seconds
+(e.g. `/event/rjQ96kl#clip=29.32,31.24`). The transcript element's DOM id is
+intentionally `clip` so HAL's hash-parser produces a short share URL.
+
+**Receiving a deeplink** is mostly HAL's job:
+
+- `setupTranscriptHash` parses the hash into `[start, end]`.
+- `setupInitialPlayHead` calls `updateTranscriptVisualState(start)` to position
+  the transcript highlight at the start, autoscrolls to that paragraph, and
+  applies a `.share-match` class to every word in the `[start, end]` range.
+- `checkStatus` auto-pauses playback when `currentTime` exceeds `end`.
+
+HAL does **not** seek the player on load, so the component reads
+`hal.hashArray[0]` after init and sets `video.currentTime` itself (deferring
+to a `loadedmetadata` listener if metadata isn't ready yet). Visited words
+in the range are styled via CSS — see `span.share-match`.
+
+**Creating a deeplink** is wired in the component, not in HAL. HAL's built-in
+`setupPopover` is gated behind `if (typeof popover !== 'undefined')` and
+expects five host-supplied DOM nodes; instead, the component listens for
+`mouseup` / `touchend` (not `selectionchange`, which fires mid-drag and
+makes the popover flicker), and when the user finishes selecting text inside
+the transcript, shows a small floating popover with two buttons:
+
+- **Copy link** — writes `${origin}${pathname}#clip=START,END` to the
+  clipboard.
+- **Copy with quote** — writes `"selected text"\n\n${url}` to the clipboard,
+  whitespace-collapsed.
+
+Both buttons preventDefault on mousedown so clicking them doesn't collapse
+the document selection before the click handler reads it. If the Clipboard
+API isn't available, both fall back to writing the fragment to
+`location.hash` so the user can copy from the URL bar.
+
+## How captions work
+
+`src/lib/caption.js` (HAL's caption generator, vendored from the same repo)
+walks the `data-m` / `data-d` spans and produces a WebVTT string. It looks
+for an existing `<track id="${playerId}-vtt">` and populates its `src` with
+a `data:text/vtt,...` URL once the video fires `loadedmetadata`.
+
+The component:
+
+1. Appends a `<track>` element to the `<video>` (kind=captions, label="English",
+   srclang="en", default=true) after HAL initializes.
+2. Calls `caption().init(transcriptId, video.id, undefined, undefined, "English", "en")`.
+
+`VodPlayer`'s Plyr config sets:
+
+- `controls: [... "captions", "settings", ...]` — adds the CC button.
+- `settings: ["captions", "speed"]` — adds caption selection in the gear menu.
+- `captions: { active: true, language: "auto", update: true }` — `update: true`
+  is the key: it tells Plyr to re-detect `<track>` elements added after Plyr
+  initialization, which is what our component does.
+
+Plyr auto-hides the CC button on videos that have no `<track>`, so this is
+safe for talks without a transcript file.
+
+## Vendored dependencies
+
+Hyperaudio Lite isn't published to npm. Both files have an MIT license. They
+are vendored under `src/lib/`:
+
+- `src/lib/hyperaudio-lite.js` — the HAL runtime, [v2.4.2](https://github.com/hyperaudio/hyperaudio-lite/blob/v2.4.2/js/hyperaudio-lite.js).
+- `src/lib/caption.js` — HAL's caption.js, [v2.4.2 tag](https://github.com/hyperaudio/hyperaudio-lite/blob/v2.4.2/js/caption.js)
+  (file's own version comment says 2.1.4 — that's an upstream maintenance
+  quirk, not a packaging mistake).
+
+The **only modification** from upstream in each file is a single appended
+ESM export line:
+
+```js
+export { HyperaudioLite };   // in hyperaudio-lite.js
+export { caption };          // in caption.js
+```
+
+This is needed because upstream's CommonJS export is gated behind
+`if (typeof module !== 'undefined' && module.exports)`, which Vite's static
+analyzer doesn't pick up. The shim is labeled with a `TEMPORARY` comment.
+
+### Upgrade path
+
+The plan is to ship a sibling `hyperaudio-lite.mjs` (and `caption.mjs`) in
+the upstream HAL repo so this codebase can swap the vendored files for a
+direct GitHub deep-path import or, eventually, an npm package. When that
+lands, delete both files under `src/lib/` and update the imports in
+`InteractiveTranscript.astro`.
+
+## Refreshing the vendored files
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hyperaudio/hyperaudio-lite/v2.4.2/js/hyperaudio-lite.js \
+  -o src/lib/hyperaudio-lite.js
+curl -fsSL https://raw.githubusercontent.com/hyperaudio/hyperaudio-lite/v2.4.2/js/caption.js \
+  -o src/lib/caption.js
+# then re-add `export { HyperaudioLite };` / `export { caption };` at the
+# bottom of each file (look at the previous git history if you forget).
+```

--- a/src/content/transcripts/rjQ96kl.json
+++ b/src/content/transcripts/rjQ96kl.json
@@ -1,0 +1,24393 @@
+{
+  "words": [
+    {
+      "start": 1.44,
+      "end": 2,
+      "text": "Hello?"
+    },
+    {
+      "start": 2,
+      "end": 2.64,
+      "text": "Hello?"
+    },
+    {
+      "start": 6.88,
+      "end": 7.68,
+      "text": "Okay."
+    },
+    {
+      "start": 7.68,
+      "end": 8.16,
+      "text": "Hey,"
+    },
+    {
+      "start": 8.16,
+      "end": 8.72,
+      "text": "everybody."
+    },
+    {
+      "start": 8.72,
+      "end": 9.04,
+      "text": "My"
+    },
+    {
+      "start": 9.04,
+      "end": 9.12,
+      "text": "name"
+    },
+    {
+      "start": 9.12,
+      "end": 9.28,
+      "text": "is"
+    },
+    {
+      "start": 9.28,
+      "end": 9.52,
+      "text": "Daniel"
+    },
+    {
+      "start": 9.52,
+      "end": 10.32,
+      "text": "Holmgren."
+    },
+    {
+      "start": 10.32,
+      "end": 10.72,
+      "text": "I'm"
+    },
+    {
+      "start": 10.72,
+      "end": 10.8,
+      "text": "the"
+    },
+    {
+      "start": 10.8,
+      "end": 10.96,
+      "text": "head"
+    },
+    {
+      "start": 10.96,
+      "end": 11.12,
+      "text": "of"
+    },
+    {
+      "start": 11.12,
+      "end": 11.44,
+      "text": "protocol"
+    },
+    {
+      "start": 11.44,
+      "end": 11.68,
+      "text": "at"
+    },
+    {
+      "start": 11.68,
+      "end": 11.92,
+      "text": "Blue"
+    },
+    {
+      "start": 11.92,
+      "end": 12.24,
+      "text": "Sky."
+    },
+    {
+      "start": 13.04,
+      "end": 13.36,
+      "text": "Just"
+    },
+    {
+      "start": 13.37,
+      "end": 13.53,
+      "text": "a"
+    },
+    {
+      "start": 13.53,
+      "end": 13.69,
+      "text": "heads"
+    },
+    {
+      "start": 13.68,
+      "end": 13.92,
+      "text": "up,"
+    },
+    {
+      "start": 13.92,
+      "end": 14.08,
+      "text": "I've"
+    },
+    {
+      "start": 14.09,
+      "end": 14.17,
+      "text": "been"
+    },
+    {
+      "start": 14.16,
+      "end": 14.4,
+      "text": "losing"
+    },
+    {
+      "start": 14.4,
+      "end": 14.64,
+      "text": "my"
+    },
+    {
+      "start": 14.64,
+      "end": 14.88,
+      "text": "voice"
+    },
+    {
+      "start": 14.88,
+      "end": 15.12,
+      "text": "all"
+    },
+    {
+      "start": 15.13,
+      "end": 15.45,
+      "text": "week."
+    },
+    {
+      "start": 15.45,
+      "end": 15.61,
+      "text": "I"
+    },
+    {
+      "start": 15.61,
+      "end": 15.77,
+      "text": "thought"
+    },
+    {
+      "start": 15.76,
+      "end": 16,
+      "text": "maybe"
+    },
+    {
+      "start": 16,
+      "end": 16.24,
+      "text": "if"
+    },
+    {
+      "start": 16.32,
+      "end": 16.96,
+      "text": "drank"
+    },
+    {
+      "start": 16.96,
+      "end": 17.28,
+      "text": "six"
+    },
+    {
+      "start": 17.29,
+      "end": 17.85,
+      "text": "Modelos"
+    },
+    {
+      "start": 17.84,
+      "end": 18,
+      "text": "at"
+    },
+    {
+      "start": 18,
+      "end": 18.24,
+      "text": "the"
+    },
+    {
+      "start": 18.24,
+      "end": 18.56,
+      "text": "after"
+    },
+    {
+      "start": 18.56,
+      "end": 18.8,
+      "text": "party"
+    },
+    {
+      "start": 18.8,
+      "end": 19.04,
+      "text": "last"
+    },
+    {
+      "start": 19.05,
+      "end": 19.37,
+      "text": "night,"
+    },
+    {
+      "start": 19.36,
+      "end": 19.44,
+      "text": "that"
+    },
+    {
+      "start": 19.45,
+      "end": 19.61,
+      "text": "would"
+    },
+    {
+      "start": 19.61,
+      "end": 20.09,
+      "text": "loosen"
+    },
+    {
+      "start": 20.09,
+      "end": 20.25,
+      "text": "it"
+    },
+    {
+      "start": 20.24,
+      "end": 20.64,
+      "text": "up."
+    },
+    {
+      "start": 20.64,
+      "end": 20.8,
+      "text": "And"
+    },
+    {
+      "start": 20.8,
+      "end": 20.88,
+      "text": "the"
+    },
+    {
+      "start": 20.88,
+      "end": 21.28,
+      "text": "jury's"
+    },
+    {
+      "start": 21.29,
+      "end": 21.45,
+      "text": "out"
+    },
+    {
+      "start": 21.45,
+      "end": 21.61,
+      "text": "on"
+    },
+    {
+      "start": 21.61,
+      "end": 21.77,
+      "text": "if"
+    },
+    {
+      "start": 21.77,
+      "end": 22.01,
+      "text": "that's"
+    },
+    {
+      "start": 22,
+      "end": 22.24,
+      "text": "working"
+    },
+    {
+      "start": 22.24,
+      "end": 22.48,
+      "text": "or"
+    },
+    {
+      "start": 22.48,
+      "end": 22.72,
+      "text": "not."
+    },
+    {
+      "start": 22.72,
+      "end": 23.2,
+      "text": "So,"
+    },
+    {
+      "start": 23.36,
+      "end": 23.6,
+      "text": "I'm"
+    },
+    {
+      "start": 23.61,
+      "end": 23.93,
+      "text": "hoping"
+    },
+    {
+      "start": 23.93,
+      "end": 24.01,
+      "text": "that"
+    },
+    {
+      "start": 24,
+      "end": 24.24,
+      "text": "I'm"
+    },
+    {
+      "start": 24.24,
+      "end": 24.4,
+      "text": "good"
+    },
+    {
+      "start": 24.4,
+      "end": 24.56,
+      "text": "for"
+    },
+    {
+      "start": 24.56,
+      "end": 24.72,
+      "text": "the"
+    },
+    {
+      "start": 24.88,
+      "end": 25.04,
+      "text": "for"
+    },
+    {
+      "start": 25.04,
+      "end": 25.28,
+      "text": "this"
+    },
+    {
+      "start": 25.29,
+      "end": 25.53,
+      "text": "talk."
+    },
+    {
+      "start": 27.24,
+      "end": 27.48,
+      "text": "To"
+    },
+    {
+      "start": 27.48,
+      "end": 27.64,
+      "text": "tell"
+    },
+    {
+      "start": 27.64,
+      "end": 27.72,
+      "text": "you"
+    },
+    {
+      "start": 27.72,
+      "end": 27.88,
+      "text": "a"
+    },
+    {
+      "start": 27.88,
+      "end": 27.96,
+      "text": "little"
+    },
+    {
+      "start": 27.96,
+      "end": 28.12,
+      "text": "bit"
+    },
+    {
+      "start": 28.12,
+      "end": 28.28,
+      "text": "about"
+    },
+    {
+      "start": 28.44,
+      "end": 28.6,
+      "text": "so"
+    },
+    {
+      "start": 28.6,
+      "end": 28.84,
+      "text": "I"
+    },
+    {
+      "start": 28.84,
+      "end": 29,
+      "text": "I"
+    },
+    {
+      "start": 29,
+      "end": 29.32,
+      "text": "lead"
+    },
+    {
+      "start": 29.32,
+      "end": 30.12,
+      "text": "protocol"
+    },
+    {
+      "start": 30.36,
+      "end": 30.76,
+      "text": "development"
+    },
+    {
+      "start": 30.76,
+      "end": 31,
+      "text": "and"
+    },
+    {
+      "start": 31,
+      "end": 31.24,
+      "text": "design"
+    },
+    {
+      "start": 31.24,
+      "end": 31.4,
+      "text": "at"
+    },
+    {
+      "start": 31.4,
+      "end": 31.64,
+      "text": "Blue"
+    },
+    {
+      "start": 31.64,
+      "end": 32.2,
+      "text": "Sky."
+    },
+    {
+      "start": 32.36,
+      "end": 32.52,
+      "text": "tell"
+    },
+    {
+      "start": 32.6,
+      "end": 32.76,
+      "text": "a"
+    },
+    {
+      "start": 32.84,
+      "end": 33.08,
+      "text": "bit"
+    },
+    {
+      "start": 33.08,
+      "end": 33.4,
+      "text": "about"
+    },
+    {
+      "start": 33.4,
+      "end": 33.56,
+      "text": "our"
+    },
+    {
+      "start": 33.56,
+      "end": 34.04,
+      "text": "team,"
+    },
+    {
+      "start": 34.04,
+      "end": 34.2,
+      "text": "right"
+    },
+    {
+      "start": 34.2,
+      "end": 34.36,
+      "text": "now"
+    },
+    {
+      "start": 34.36,
+      "end": 34.6,
+      "text": "it's"
+    },
+    {
+      "start": 34.6,
+      "end": 34.92,
+      "text": "technically"
+    },
+    {
+      "start": 34.92,
+      "end": 35.16,
+      "text": "just"
+    },
+    {
+      "start": 35.16,
+      "end": 35.32,
+      "text": "me"
+    },
+    {
+      "start": 35.32,
+      "end": 35.48,
+      "text": "and"
+    },
+    {
+      "start": 35.48,
+      "end": 35.72,
+      "text": "Brian"
+    },
+    {
+      "start": 35.72,
+      "end": 36.2,
+      "text": "Newbold"
+    },
+    {
+      "start": 36.2,
+      "end": 36.44,
+      "text": "on"
+    },
+    {
+      "start": 36.44,
+      "end": 36.84,
+      "text": "it."
+    },
+    {
+      "start": 36.92,
+      "end": 37.24,
+      "text": "Although,"
+    },
+    {
+      "start": 37.24,
+      "end": 37.32,
+      "text": "we"
+    },
+    {
+      "start": 37.32,
+      "end": 37.72,
+      "text": "collaborate"
+    },
+    {
+      "start": 37.72,
+      "end": 38.04,
+      "text": "closely"
+    },
+    {
+      "start": 38.04,
+      "end": 38.2,
+      "text": "with"
+    },
+    {
+      "start": 38.2,
+      "end": 38.44,
+      "text": "other"
+    },
+    {
+      "start": 38.44,
+      "end": 38.6,
+      "text": "folks"
+    },
+    {
+      "start": 38.6,
+      "end": 38.76,
+      "text": "from"
+    },
+    {
+      "start": 38.76,
+      "end": 38.92,
+      "text": "the"
+    },
+    {
+      "start": 38.92,
+      "end": 39.24,
+      "text": "atmosphere"
+    },
+    {
+      "start": 39.24,
+      "end": 39.56,
+      "text": "team."
+    },
+    {
+      "start": 39.73,
+      "end": 40.13,
+      "text": "Without"
+    },
+    {
+      "start": 40.14,
+      "end": 40.38,
+      "text": "going"
+    },
+    {
+      "start": 40.38,
+      "end": 40.62,
+      "text": "into"
+    },
+    {
+      "start": 40.62,
+      "end": 40.7,
+      "text": "our"
+    },
+    {
+      "start": 40.7,
+      "end": 40.86,
+      "text": "whole"
+    },
+    {
+      "start": 40.85,
+      "end": 41.17,
+      "text": "org"
+    },
+    {
+      "start": 41.17,
+      "end": 41.65,
+      "text": "structure,"
+    },
+    {
+      "start": 41.66,
+      "end": 41.82,
+      "text": "the"
+    },
+    {
+      "start": 41.82,
+      "end": 42.06,
+      "text": "reason"
+    },
+    {
+      "start": 42.05,
+      "end": 42.21,
+      "text": "that"
+    },
+    {
+      "start": 42.22,
+      "end": 42.3,
+      "text": "we"
+    },
+    {
+      "start": 42.3,
+      "end": 42.7,
+      "text": "split"
+    },
+    {
+      "start": 42.7,
+      "end": 42.94,
+      "text": "out"
+    },
+    {
+      "start": 42.94,
+      "end": 43.1,
+      "text": "this"
+    },
+    {
+      "start": 43.09,
+      "end": 43.49,
+      "text": "protocol"
+    },
+    {
+      "start": 43.49,
+      "end": 43.89,
+      "text": "department"
+    },
+    {
+      "start": 43.9,
+      "end": 44.14,
+      "text": "is"
+    },
+    {
+      "start": 44.14,
+      "end": 44.62,
+      "text": "that"
+    },
+    {
+      "start": 44.62,
+      "end": 45.02,
+      "text": "protocol"
+    },
+    {
+      "start": 45.02,
+      "end": 45.42,
+      "text": "design"
+    },
+    {
+      "start": 45.41,
+      "end": 45.65,
+      "text": "and"
+    },
+    {
+      "start": 45.66,
+      "end": 46.22,
+      "text": "government"
+    },
+    {
+      "start": 46.3,
+      "end": 47.1,
+      "text": "governance"
+    },
+    {
+      "start": 47.09,
+      "end": 47.41,
+      "text": "just"
+    },
+    {
+      "start": 47.41,
+      "end": 47.81,
+      "text": "looks"
+    },
+    {
+      "start": 47.82,
+      "end": 48.14,
+      "text": "pretty"
+    },
+    {
+      "start": 48.14,
+      "end": 48.46,
+      "text": "different"
+    },
+    {
+      "start": 48.45,
+      "end": 48.69,
+      "text": "from"
+    },
+    {
+      "start": 48.7,
+      "end": 48.94,
+      "text": "running"
+    },
+    {
+      "start": 48.94,
+      "end": 49.1,
+      "text": "a"
+    },
+    {
+      "start": 49.09,
+      "end": 49.65,
+      "text": "startup."
+    },
+    {
+      "start": 49.73,
+      "end": 49.89,
+      "text": "You"
+    },
+    {
+      "start": 49.9,
+      "end": 50.14,
+      "text": "wanna"
+    },
+    {
+      "start": 50.14,
+      "end": 50.38,
+      "text": "make"
+    },
+    {
+      "start": 50.38,
+      "end": 50.86,
+      "text": "slower"
+    },
+    {
+      "start": 50.85,
+      "end": 51.57,
+      "text": "intentional"
+    },
+    {
+      "start": 51.58,
+      "end": 52.22,
+      "text": "decisions"
+    },
+    {
+      "start": 52.22,
+      "end": 53.02,
+      "text": "and"
+    },
+    {
+      "start": 52.25,
+      "end": 52.49,
+      "text": "you"
+    },
+    {
+      "start": 52.49,
+      "end": 52.65,
+      "text": "don't"
+    },
+    {
+      "start": 52.65,
+      "end": 52.81,
+      "text": "want"
+    },
+    {
+      "start": 52.81,
+      "end": 52.89,
+      "text": "it"
+    },
+    {
+      "start": 52.89,
+      "end": 52.97,
+      "text": "to"
+    },
+    {
+      "start": 52.97,
+      "end": 53.13,
+      "text": "get"
+    },
+    {
+      "start": 53.13,
+      "end": 53.29,
+      "text": "caught"
+    },
+    {
+      "start": 53.29,
+      "end": 53.45,
+      "text": "up"
+    },
+    {
+      "start": 53.45,
+      "end": 53.61,
+      "text": "in"
+    },
+    {
+      "start": 53.61,
+      "end": 53.77,
+      "text": "sort"
+    },
+    {
+      "start": 53.77,
+      "end": 53.93,
+      "text": "of"
+    },
+    {
+      "start": 53.93,
+      "end": 54.17,
+      "text": "the"
+    },
+    {
+      "start": 54.17,
+      "end": 54.41,
+      "text": "the"
+    },
+    {
+      "start": 54.41,
+      "end": 54.81,
+      "text": "market"
+    },
+    {
+      "start": 54.81,
+      "end": 55.05,
+      "text": "and"
+    },
+    {
+      "start": 55.05,
+      "end": 55.21,
+      "text": "the"
+    },
+    {
+      "start": 55.21,
+      "end": 55.61,
+      "text": "product"
+    },
+    {
+      "start": 55.61,
+      "end": 55.85,
+      "text": "life"
+    },
+    {
+      "start": 55.85,
+      "end": 56.49,
+      "text": "cycle"
+    },
+    {
+      "start": 56.65,
+      "end": 57.05,
+      "text": "of"
+    },
+    {
+      "start": 57.05,
+      "end": 57.29,
+      "text": "the"
+    },
+    {
+      "start": 57.29,
+      "end": 57.77,
+      "text": "startup."
+    },
+    {
+      "start": 57.77,
+      "end": 58.01,
+      "text": "So,"
+    },
+    {
+      "start": 58.01,
+      "end": 58.09,
+      "text": "we"
+    },
+    {
+      "start": 58.09,
+      "end": 58.33,
+      "text": "put"
+    },
+    {
+      "start": 58.33,
+      "end": 58.49,
+      "text": "up"
+    },
+    {
+      "start": 58.49,
+      "end": 58.65,
+      "text": "a"
+    },
+    {
+      "start": 58.65,
+      "end": 58.81,
+      "text": "little"
+    },
+    {
+      "start": 58.81,
+      "end": 58.89,
+      "text": "bit"
+    },
+    {
+      "start": 58.89,
+      "end": 59.05,
+      "text": "of"
+    },
+    {
+      "start": 59.05,
+      "end": 59.21,
+      "text": "a"
+    },
+    {
+      "start": 59.21,
+      "end": 59.77,
+      "text": "internal"
+    },
+    {
+      "start": 59.77,
+      "end": 60.25,
+      "text": "firewall"
+    },
+    {
+      "start": 60.25,
+      "end": 60.65,
+      "text": "for"
+    },
+    {
+      "start": 60.65,
+      "end": 60.81,
+      "text": "that"
+    },
+    {
+      "start": 60.81,
+      "end": 61.45,
+      "text": "department."
+    },
+    {
+      "start": 61.53,
+      "end": 61.69,
+      "text": "So,"
+    },
+    {
+      "start": 61.69,
+      "end": 61.85,
+      "text": "we"
+    },
+    {
+      "start": 61.85,
+      "end": 62.09,
+      "text": "can"
+    },
+    {
+      "start": 62.09,
+      "end": 62.33,
+      "text": "go"
+    },
+    {
+      "start": 62.33,
+      "end": 62.49,
+      "text": "a"
+    },
+    {
+      "start": 62.49,
+      "end": 62.57,
+      "text": "little"
+    },
+    {
+      "start": 62.57,
+      "end": 62.73,
+      "text": "bit"
+    },
+    {
+      "start": 62.73,
+      "end": 63.05,
+      "text": "slower"
+    },
+    {
+      "start": 63.05,
+      "end": 63.21,
+      "text": "and"
+    },
+    {
+      "start": 63.21,
+      "end": 63.37,
+      "text": "we"
+    },
+    {
+      "start": 63.37,
+      "end": 63.53,
+      "text": "can"
+    },
+    {
+      "start": 63.53,
+      "end": 63.61,
+      "text": "be"
+    },
+    {
+      "start": 63.61,
+      "end": 63.85,
+      "text": "focused"
+    },
+    {
+      "start": 63.85,
+      "end": 64.25,
+      "text": "on"
+    },
+    {
+      "start": 64.25,
+      "end": 64.49,
+      "text": "what"
+    },
+    {
+      "start": 64.89,
+      "end": 65.13,
+      "text": "care"
+    },
+    {
+      "start": 65.45,
+      "end": 65.53,
+      "text": "the"
+    },
+    {
+      "start": 65.53,
+      "end": 65.93,
+      "text": "protocol,"
+    },
+    {
+      "start": 66.36,
+      "end": 66.68,
+      "text": "which"
+    },
+    {
+      "start": 66.67,
+      "end": 66.75,
+      "text": "is"
+    },
+    {
+      "start": 66.75,
+      "end": 66.99,
+      "text": "the"
+    },
+    {
+      "start": 67,
+      "end": 67.32,
+      "text": "emergence"
+    },
+    {
+      "start": 67.31,
+      "end": 67.55,
+      "text": "of"
+    },
+    {
+      "start": 67.56,
+      "end": 67.72,
+      "text": "a"
+    },
+    {
+      "start": 67.72,
+      "end": 68.2,
+      "text": "functioning"
+    },
+    {
+      "start": 68.19,
+      "end": 68.75,
+      "text": "resilient"
+    },
+    {
+      "start": 68.75,
+      "end": 69.15,
+      "text": "multi"
+    },
+    {
+      "start": 69.16,
+      "end": 69.72,
+      "text": "stakeholder"
+    },
+    {
+      "start": 69.72,
+      "end": 70.68,
+      "text": "atmosphere."
+    },
+    {
+      "start": 74.11,
+      "end": 74.51,
+      "text": "So,"
+    },
+    {
+      "start": 74.52,
+      "end": 74.6,
+      "text": "I"
+    },
+    {
+      "start": 74.59,
+      "end": 74.83,
+      "text": "want"
+    },
+    {
+      "start": 74.83,
+      "end": 74.91,
+      "text": "to"
+    },
+    {
+      "start": 74.92,
+      "end": 75.08,
+      "text": "start"
+    },
+    {
+      "start": 75.08,
+      "end": 75.24,
+      "text": "with"
+    },
+    {
+      "start": 75.23,
+      "end": 75.39,
+      "text": "the"
+    },
+    {
+      "start": 75.39,
+      "end": 76.11,
+      "text": "provocation,"
+    },
+    {
+      "start": 76.11,
+      "end": 76.27,
+      "text": "is"
+    },
+    {
+      "start": 76.28,
+      "end": 76.44,
+      "text": "that"
+    },
+    {
+      "start": 76.44,
+      "end": 76.68,
+      "text": "it's"
+    },
+    {
+      "start": 76.67,
+      "end": 77.07,
+      "text": "logically"
+    },
+    {
+      "start": 77.08,
+      "end": 77.56,
+      "text": "impossible"
+    },
+    {
+      "start": 77.56,
+      "end": 77.88,
+      "text": "for"
+    },
+    {
+      "start": 77.88,
+      "end": 78.12,
+      "text": "Blue"
+    },
+    {
+      "start": 78.11,
+      "end": 78.27,
+      "text": "Sky"
+    },
+    {
+      "start": 78.28,
+      "end": 78.52,
+      "text": "to"
+    },
+    {
+      "start": 78.52,
+      "end": 79.08,
+      "text": "decentralize"
+    },
+    {
+      "start": 79.08,
+      "end": 79.24,
+      "text": "the"
+    },
+    {
+      "start": 79.23,
+      "end": 79.55,
+      "text": "network."
+    },
+    {
+      "start": 79.91,
+      "end": 80.23,
+      "text": "We"
+    },
+    {
+      "start": 80.23,
+      "end": 80.47,
+      "text": "really"
+    },
+    {
+      "start": 80.47,
+      "end": 80.71,
+      "text": "want"
+    },
+    {
+      "start": 80.71,
+      "end": 80.87,
+      "text": "the"
+    },
+    {
+      "start": 80.87,
+      "end": 81.19,
+      "text": "network"
+    },
+    {
+      "start": 81.19,
+      "end": 81.35,
+      "text": "to"
+    },
+    {
+      "start": 81.35,
+      "end": 81.43,
+      "text": "be"
+    },
+    {
+      "start": 81.43,
+      "end": 82.31,
+      "text": "decentralized."
+    },
+    {
+      "start": 82.31,
+      "end": 82.47,
+      "text": "It"
+    },
+    {
+      "start": 82.47,
+      "end": 82.63,
+      "text": "is"
+    },
+    {
+      "start": 82.63,
+      "end": 83.43,
+      "text": "impossible"
+    },
+    {
+      "start": 83.43,
+      "end": 83.67,
+      "text": "for"
+    },
+    {
+      "start": 83.67,
+      "end": 83.91,
+      "text": "us"
+    },
+    {
+      "start": 83.91,
+      "end": 84.07,
+      "text": "to"
+    },
+    {
+      "start": 84.07,
+      "end": 84.23,
+      "text": "do"
+    },
+    {
+      "start": 84.23,
+      "end": 84.63,
+      "text": "it"
+    },
+    {
+      "start": 84.63,
+      "end": 85.11,
+      "text": "because"
+    },
+    {
+      "start": 85.11,
+      "end": 85.35,
+      "text": "we"
+    },
+    {
+      "start": 85.35,
+      "end": 85.83,
+      "text": "are"
+    },
+    {
+      "start": 85.83,
+      "end": 86.15,
+      "text": "the"
+    },
+    {
+      "start": 86.15,
+      "end": 86.63,
+      "text": "party."
+    },
+    {
+      "start": 86.63,
+      "end": 86.95,
+      "text": "Right?"
+    },
+    {
+      "start": 86.95,
+      "end": 87.19,
+      "text": "And"
+    },
+    {
+      "start": 87.19,
+      "end": 87.51,
+      "text": "even"
+    },
+    {
+      "start": 87.51,
+      "end": 87.67,
+      "text": "if"
+    },
+    {
+      "start": 87.67,
+      "end": 87.83,
+      "text": "we"
+    },
+    {
+      "start": 87.83,
+      "end": 88.15,
+      "text": "funded"
+    },
+    {
+      "start": 88.15,
+      "end": 88.47,
+      "text": "somebody"
+    },
+    {
+      "start": 88.47,
+      "end": 88.63,
+      "text": "else"
+    },
+    {
+      "start": 88.63,
+      "end": 88.79,
+      "text": "to"
+    },
+    {
+      "start": 88.79,
+      "end": 88.87,
+      "text": "do"
+    },
+    {
+      "start": 88.87,
+      "end": 89.11,
+      "text": "it,"
+    },
+    {
+      "start": 89.11,
+      "end": 89.27,
+      "text": "they're"
+    },
+    {
+      "start": 89.27,
+      "end": 89.43,
+      "text": "still"
+    },
+    {
+      "start": 89.43,
+      "end": 89.75,
+      "text": "downstream"
+    },
+    {
+      "start": 89.75,
+      "end": 89.99,
+      "text": "of"
+    },
+    {
+      "start": 89.99,
+      "end": 90.15,
+      "text": "us"
+    },
+    {
+      "start": 90.15,
+      "end": 90.47,
+      "text": "and"
+    },
+    {
+      "start": 90.47,
+      "end": 90.63,
+      "text": "it's"
+    },
+    {
+      "start": 90.63,
+      "end": 90.79,
+      "text": "not"
+    },
+    {
+      "start": 90.79,
+      "end": 91.03,
+      "text": "actually"
+    },
+    {
+      "start": 91.19,
+      "end": 91.35,
+      "text": "do"
+    },
+    {
+      "start": 91.35,
+      "end": 91.43,
+      "text": "they"
+    },
+    {
+      "start": 91.43,
+      "end": 91.67,
+      "text": "actually"
+    },
+    {
+      "start": 91.67,
+      "end": 91.83,
+      "text": "have"
+    },
+    {
+      "start": 91.83,
+      "end": 91.99,
+      "text": "the"
+    },
+    {
+      "start": 91.99,
+      "end": 92.39,
+      "text": "authority?"
+    },
+    {
+      "start": 92.39,
+      "end": 92.55,
+      "text": "Do"
+    },
+    {
+      "start": 92.55,
+      "end": 92.63,
+      "text": "they"
+    },
+    {
+      "start": 92.63,
+      "end": 92.87,
+      "text": "actually"
+    },
+    {
+      "start": 92.87,
+      "end": 93.03,
+      "text": "have"
+    },
+    {
+      "start": 93.03,
+      "end": 93.11,
+      "text": "the"
+    },
+    {
+      "start": 93.11,
+      "end": 93.67,
+      "text": "power?"
+    },
+    {
+      "start": 94.07,
+      "end": 94.15,
+      "text": "And"
+    },
+    {
+      "start": 95.72,
+      "end": 96.04,
+      "text": "We're"
+    },
+    {
+      "start": 96.05,
+      "end": 96.21,
+      "text": "the"
+    },
+    {
+      "start": 96.2,
+      "end": 96.52,
+      "text": "central"
+    },
+    {
+      "start": 96.52,
+      "end": 97.16,
+      "text": "entity."
+    },
+    {
+      "start": 97.16,
+      "end": 97.32,
+      "text": "We"
+    },
+    {
+      "start": 97.33,
+      "end": 97.65,
+      "text": "can't"
+    },
+    {
+      "start": 97.64,
+      "end": 98.36,
+      "text": "decentralize"
+    },
+    {
+      "start": 98.36,
+      "end": 98.84,
+      "text": "it."
+    },
+    {
+      "start": 99.24,
+      "end": 99.48,
+      "text": "We"
+    },
+    {
+      "start": 99.48,
+      "end": 99.64,
+      "text": "can"
+    },
+    {
+      "start": 99.64,
+      "end": 99.88,
+      "text": "provide"
+    },
+    {
+      "start": 99.88,
+      "end": 100.04,
+      "text": "the"
+    },
+    {
+      "start": 100.05,
+      "end": 100.37,
+      "text": "tools"
+    },
+    {
+      "start": 100.36,
+      "end": 100.68,
+      "text": "and"
+    },
+    {
+      "start": 100.69,
+      "end": 101.41,
+      "text": "structures"
+    },
+    {
+      "start": 101.41,
+      "end": 101.73,
+      "text": "by"
+    },
+    {
+      "start": 101.72,
+      "end": 101.96,
+      "text": "which"
+    },
+    {
+      "start": 101.97,
+      "end": 102.13,
+      "text": "to"
+    },
+    {
+      "start": 102.13,
+      "end": 102.77,
+      "text": "decentralize"
+    },
+    {
+      "start": 102.77,
+      "end": 103.17,
+      "text": "it,"
+    },
+    {
+      "start": 103.16,
+      "end": 103.32,
+      "text": "but"
+    },
+    {
+      "start": 103.33,
+      "end": 103.49,
+      "text": "we"
+    },
+    {
+      "start": 103.48,
+      "end": 103.72,
+      "text": "need"
+    },
+    {
+      "start": 103.72,
+      "end": 104.04,
+      "text": "others"
+    },
+    {
+      "start": 104.05,
+      "end": 104.29,
+      "text": "to"
+    },
+    {
+      "start": 104.28,
+      "end": 104.52,
+      "text": "use"
+    },
+    {
+      "start": 104.52,
+      "end": 104.76,
+      "text": "those"
+    },
+    {
+      "start": 104.77,
+      "end": 105.01,
+      "text": "tools"
+    },
+    {
+      "start": 105,
+      "end": 105.16,
+      "text": "and"
+    },
+    {
+      "start": 105.16,
+      "end": 105.72,
+      "text": "structures"
+    },
+    {
+      "start": 105.72,
+      "end": 106.04,
+      "text": "to"
+    },
+    {
+      "start": 106.05,
+      "end": 106.29,
+      "text": "take"
+    },
+    {
+      "start": 106.28,
+      "end": 107,
+      "text": "control,"
+    },
+    {
+      "start": 107,
+      "end": 107.64,
+      "text": "power,"
+    },
+    {
+      "start": 107.64,
+      "end": 107.8,
+      "text": "and"
+    },
+    {
+      "start": 107.8,
+      "end": 108.12,
+      "text": "authority"
+    },
+    {
+      "start": 108.13,
+      "end": 108.29,
+      "text": "in"
+    },
+    {
+      "start": 108.28,
+      "end": 108.44,
+      "text": "the"
+    },
+    {
+      "start": 108.44,
+      "end": 108.76,
+      "text": "network"
+    },
+    {
+      "start": 108.81,
+      "end": 109.13,
+      "text": "to"
+    },
+    {
+      "start": 109.13,
+      "end": 109.45,
+      "text": "actually"
+    },
+    {
+      "start": 109.45,
+      "end": 109.69,
+      "text": "make"
+    },
+    {
+      "start": 109.69,
+      "end": 109.85,
+      "text": "this"
+    },
+    {
+      "start": 109.85,
+      "end": 110.01,
+      "text": "a"
+    },
+    {
+      "start": 110.01,
+      "end": 110.49,
+      "text": "resilient"
+    },
+    {
+      "start": 110.49,
+      "end": 110.89,
+      "text": "multi"
+    },
+    {
+      "start": 110.89,
+      "end": 111.37,
+      "text": "stakeholder"
+    },
+    {
+      "start": 111.37,
+      "end": 112.09,
+      "text": "network."
+    },
+    {
+      "start": 114.01,
+      "end": 114.33,
+      "text": "So,"
+    },
+    {
+      "start": 114.33,
+      "end": 114.49,
+      "text": "that's"
+    },
+    {
+      "start": 114.49,
+      "end": 114.65,
+      "text": "what"
+    },
+    {
+      "start": 114.65,
+      "end": 114.81,
+      "text": "I'm"
+    },
+    {
+      "start": 114.81,
+      "end": 114.89,
+      "text": "gonna"
+    },
+    {
+      "start": 114.89,
+      "end": 115.05,
+      "text": "be"
+    },
+    {
+      "start": 115.05,
+      "end": 115.29,
+      "text": "talking"
+    },
+    {
+      "start": 115.29,
+      "end": 115.37,
+      "text": "about"
+    },
+    {
+      "start": 115.37,
+      "end": 115.61,
+      "text": "today"
+    },
+    {
+      "start": 115.61,
+      "end": 115.77,
+      "text": "is"
+    },
+    {
+      "start": 115.77,
+      "end": 115.93,
+      "text": "those"
+    },
+    {
+      "start": 115.93,
+      "end": 116.17,
+      "text": "tools"
+    },
+    {
+      "start": 116.17,
+      "end": 116.41,
+      "text": "and"
+    },
+    {
+      "start": 116.41,
+      "end": 116.65,
+      "text": "structures"
+    },
+    {
+      "start": 116.65,
+      "end": 116.89,
+      "text": "and"
+    },
+    {
+      "start": 116.89,
+      "end": 117.05,
+      "text": "how"
+    },
+    {
+      "start": 117.05,
+      "end": 117.21,
+      "text": "we"
+    },
+    {
+      "start": 117.21,
+      "end": 117.45,
+      "text": "address"
+    },
+    {
+      "start": 117.45,
+      "end": 117.93,
+      "text": "that."
+    },
+    {
+      "start": 117.93,
+      "end": 118.09,
+      "text": "The"
+    },
+    {
+      "start": 118.09,
+      "end": 118.57,
+      "text": "agenda"
+    },
+    {
+      "start": 118.57,
+      "end": 119.05,
+      "text": "is"
+    },
+    {
+      "start": 119.05,
+      "end": 119.37,
+      "text": "pretty"
+    },
+    {
+      "start": 119.37,
+      "end": 119.77,
+      "text": "brief."
+    },
+    {
+      "start": 119.77,
+      "end": 120.01,
+      "text": "We're"
+    },
+    {
+      "start": 120.01,
+      "end": 120.17,
+      "text": "gonna"
+    },
+    {
+      "start": 120.17,
+      "end": 120.33,
+      "text": "talk"
+    },
+    {
+      "start": 120.33,
+      "end": 120.49,
+      "text": "about"
+    },
+    {
+      "start": 120.49,
+      "end": 120.57,
+      "text": "the"
+    },
+    {
+      "start": 120.57,
+      "end": 121.53,
+      "text": "IETF,"
+    },
+    {
+      "start": 121.69,
+      "end": 121.85,
+      "text": "some"
+    },
+    {
+      "start": 121.85,
+      "end": 122.17,
+      "text": "recent"
+    },
+    {
+      "start": 122.17,
+      "end": 122.57,
+      "text": "developments"
+    },
+    {
+      "start": 122.57,
+      "end": 122.81,
+      "text": "with"
+    },
+    {
+      "start": 122.81,
+      "end": 123.37,
+      "text": "PLC"
+    },
+    {
+      "start": 123.37,
+      "end": 123.85,
+      "text": "governance,"
+    },
+    {
+      "start": 124.17,
+      "end": 124.41,
+      "text": "and"
+    },
+    {
+      "start": 124.42,
+      "end": 124.9,
+      "text": "then,"
+    },
+    {
+      "start": 125.06,
+      "end": 125.46,
+      "text": "hard"
+    },
+    {
+      "start": 125.45,
+      "end": 126.41,
+      "text": "decentralization,"
+    },
+    {
+      "start": 126.42,
+      "end": 126.5,
+      "text": "which"
+    },
+    {
+      "start": 126.5,
+      "end": 126.66,
+      "text": "is"
+    },
+    {
+      "start": 126.66,
+      "end": 126.82,
+      "text": "kind"
+    },
+    {
+      "start": 126.81,
+      "end": 126.89,
+      "text": "of"
+    },
+    {
+      "start": 126.9,
+      "end": 127.14,
+      "text": "getting"
+    },
+    {
+      "start": 127.14,
+      "end": 127.38,
+      "text": "into"
+    },
+    {
+      "start": 127.38,
+      "end": 127.46,
+      "text": "the"
+    },
+    {
+      "start": 127.45,
+      "end": 127.77,
+      "text": "actual"
+    },
+    {
+      "start": 127.78,
+      "end": 128.1,
+      "text": "threats"
+    },
+    {
+      "start": 128.09,
+      "end": 128.33,
+      "text": "of"
+    },
+    {
+      "start": 128.34,
+      "end": 128.82,
+      "text": "what"
+    },
+    {
+      "start": 128.81,
+      "end": 129.21,
+      "text": "having"
+    },
+    {
+      "start": 129.22,
+      "end": 129.38,
+      "text": "a"
+    },
+    {
+      "start": 129.38,
+      "end": 129.62,
+      "text": "big"
+    },
+    {
+      "start": 129.62,
+      "end": 130.18,
+      "text": "entity"
+    },
+    {
+      "start": 130.18,
+      "end": 130.34,
+      "text": "in"
+    },
+    {
+      "start": 130.34,
+      "end": 130.42,
+      "text": "the"
+    },
+    {
+      "start": 130.57,
+      "end": 130.73,
+      "text": "of"
+    },
+    {
+      "start": 130.81,
+      "end": 131.21,
+      "text": "ecosystem"
+    },
+    {
+      "start": 131.22,
+      "end": 131.54,
+      "text": "could"
+    },
+    {
+      "start": 131.53,
+      "end": 132.01,
+      "text": "do."
+    },
+    {
+      "start": 133.22,
+      "end": 133.7,
+      "text": "Before"
+    },
+    {
+      "start": 133.69,
+      "end": 133.85,
+      "text": "we"
+    },
+    {
+      "start": 133.85,
+      "end": 134.01,
+      "text": "do"
+    },
+    {
+      "start": 134.01,
+      "end": 134.49,
+      "text": "that,"
+    },
+    {
+      "start": 134.5,
+      "end": 134.66,
+      "text": "I'm"
+    },
+    {
+      "start": 134.66,
+      "end": 134.82,
+      "text": "on"
+    },
+    {
+      "start": 134.81,
+      "end": 134.89,
+      "text": "the"
+    },
+    {
+      "start": 134.9,
+      "end": 135.14,
+      "text": "big"
+    },
+    {
+      "start": 135.13,
+      "end": 135.45,
+      "text": "stage"
+    },
+    {
+      "start": 135.46,
+      "end": 135.7,
+      "text": "and"
+    },
+    {
+      "start": 135.69,
+      "end": 135.85,
+      "text": "I"
+    },
+    {
+      "start": 135.85,
+      "end": 136.09,
+      "text": "wanted"
+    },
+    {
+      "start": 136.09,
+      "end": 136.17,
+      "text": "to"
+    },
+    {
+      "start": 136.18,
+      "end": 136.34,
+      "text": "talk"
+    },
+    {
+      "start": 136.34,
+      "end": 136.5,
+      "text": "about"
+    },
+    {
+      "start": 136.5,
+      "end": 136.66,
+      "text": "the"
+    },
+    {
+      "start": 136.66,
+      "end": 136.82,
+      "text": "real"
+    },
+    {
+      "start": 136.81,
+      "end": 137.21,
+      "text": "governance"
+    },
+    {
+      "start": 137.22,
+      "end": 137.7,
+      "text": "question,"
+    },
+    {
+      "start": 137.69,
+      "end": 137.77,
+      "text": "which"
+    },
+    {
+      "start": 137.78,
+      "end": 137.86,
+      "text": "is"
+    },
+    {
+      "start": 137.85,
+      "end": 138.01,
+      "text": "how"
+    },
+    {
+      "start": 138.01,
+      "end": 138.17,
+      "text": "do"
+    },
+    {
+      "start": 138.18,
+      "end": 138.26,
+      "text": "we"
+    },
+    {
+      "start": 138.25,
+      "end": 138.81,
+      "text": "capitalize"
+    },
+    {
+      "start": 138.81,
+      "end": 140.41,
+      "text": "and"
+    },
+    {
+      "start": 139.14,
+      "end": 139.7,
+      "text": "stylize"
+    },
+    {
+      "start": 139.7,
+      "end": 140.1,
+      "text": "AT"
+    },
+    {
+      "start": 140.1,
+      "end": 140.74,
+      "text": "protocol?"
+    },
+    {
+      "start": 140.74,
+      "end": 141.14,
+      "text": "Again,"
+    },
+    {
+      "start": 141.86,
+      "end": 142.02,
+      "text": "this"
+    },
+    {
+      "start": 142.02,
+      "end": 142.1,
+      "text": "is"
+    },
+    {
+      "start": 142.1,
+      "end": 142.26,
+      "text": "a"
+    },
+    {
+      "start": 142.26,
+      "end": 142.58,
+      "text": "multi"
+    },
+    {
+      "start": 142.58,
+      "end": 142.98,
+      "text": "stakeholder"
+    },
+    {
+      "start": 142.98,
+      "end": 143.54,
+      "text": "network,"
+    },
+    {
+      "start": 143.54,
+      "end": 143.62,
+      "text": "so"
+    },
+    {
+      "start": 143.62,
+      "end": 143.78,
+      "text": "this"
+    },
+    {
+      "start": 143.78,
+      "end": 143.94,
+      "text": "is"
+    },
+    {
+      "start": 143.94,
+      "end": 144.1,
+      "text": "just"
+    },
+    {
+      "start": 144.1,
+      "end": 144.26,
+      "text": "my"
+    },
+    {
+      "start": 144.26,
+      "end": 144.74,
+      "text": "opinion."
+    },
+    {
+      "start": 144.74,
+      "end": 144.82,
+      "text": "It"
+    },
+    {
+      "start": 144.82,
+      "end": 144.98,
+      "text": "just"
+    },
+    {
+      "start": 144.98,
+      "end": 145.3,
+      "text": "happens"
+    },
+    {
+      "start": 145.3,
+      "end": 145.38,
+      "text": "to"
+    },
+    {
+      "start": 145.38,
+      "end": 145.54,
+      "text": "be"
+    },
+    {
+      "start": 145.54,
+      "end": 145.7,
+      "text": "the"
+    },
+    {
+      "start": 145.7,
+      "end": 145.94,
+      "text": "correct"
+    },
+    {
+      "start": 145.94,
+      "end": 146.58,
+      "text": "opinion."
+    },
+    {
+      "start": 146.58,
+      "end": 146.9,
+      "text": "You"
+    },
+    {
+      "start": 146.9,
+      "end": 147.06,
+      "text": "can"
+    },
+    {
+      "start": 147.06,
+      "end": 147.38,
+      "text": "see"
+    },
+    {
+      "start": 147.38,
+      "end": 148.02,
+      "text": "AT"
+    },
+    {
+      "start": 148.02,
+      "end": 148.98,
+      "text": "protocol,"
+    },
+    {
+      "start": 149.3,
+      "end": 149.54,
+      "text": "at"
+    },
+    {
+      "start": 149.54,
+      "end": 150.1,
+      "text": "proto,"
+    },
+    {
+      "start": 150.1,
+      "end": 150.42,
+      "text": "all"
+    },
+    {
+      "start": 150.42,
+      "end": 150.66,
+      "text": "lower"
+    },
+    {
+      "start": 150.66,
+      "end": 151.3,
+      "text": "case,"
+    },
+    {
+      "start": 151.3,
+      "end": 151.54,
+      "text": "not"
+    },
+    {
+      "start": 151.54,
+      "end": 151.7,
+      "text": "a"
+    },
+    {
+      "start": 151.7,
+      "end": 152.02,
+      "text": "capital"
+    },
+    {
+      "start": 152.02,
+      "end": 152.66,
+      "text": "a,"
+    },
+    {
+      "start": 152.66,
+      "end": 152.82,
+      "text": "and"
+    },
+    {
+      "start": 152.82,
+      "end": 153.38,
+      "text": "atmosphere."
+    },
+    {
+      "start": 153.93,
+      "end": 154.25,
+      "text": "The"
+    },
+    {
+      "start": 154.25,
+      "end": 154.41,
+      "text": "rest"
+    },
+    {
+      "start": 154.41,
+      "end": 154.57,
+      "text": "of"
+    },
+    {
+      "start": 154.56,
+      "end": 154.8,
+      "text": "these"
+    },
+    {
+      "start": 154.81,
+      "end": 155.05,
+      "text": "are"
+    },
+    {
+      "start": 155.04,
+      "end": 155.52,
+      "text": "out,"
+    },
+    {
+      "start": 155.53,
+      "end": 155.93,
+      "text": "especially"
+    },
+    {
+      "start": 156,
+      "end": 156.4,
+      "text": "capital"
+    },
+    {
+      "start": 156.41,
+      "end": 156.81,
+      "text": "a,"
+    },
+    {
+      "start": 156.81,
+      "end": 157.05,
+      "text": "capital"
+    },
+    {
+      "start": 157.04,
+      "end": 157.52,
+      "text": "t,"
+    },
+    {
+      "start": 157.53,
+      "end": 157.77,
+      "text": "capital"
+    },
+    {
+      "start": 157.76,
+      "end": 158.08,
+      "text": "p"
+    },
+    {
+      "start": 158.08,
+      "end": 158.8,
+      "text": "proto."
+    },
+    {
+      "start": 158.81,
+      "end": 158.97,
+      "text": "That"
+    },
+    {
+      "start": 158.97,
+      "end": 159.21,
+      "text": "one"
+    },
+    {
+      "start": 159.21,
+      "end": 159.45,
+      "text": "is"
+    },
+    {
+      "start": 159.44,
+      "end": 159.92,
+      "text": "terrible"
+    },
+    {
+      "start": 159.93,
+      "end": 160.25,
+      "text": "and"
+    },
+    {
+      "start": 160.25,
+      "end": 160.41,
+      "text": "it"
+    },
+    {
+      "start": 160.41,
+      "end": 160.57,
+      "text": "needs"
+    },
+    {
+      "start": 160.56,
+      "end": 160.72,
+      "text": "to"
+    },
+    {
+      "start": 160.72,
+      "end": 160.8,
+      "text": "be"
+    },
+    {
+      "start": 160.81,
+      "end": 161.45,
+      "text": "killed."
+    },
+    {
+      "start": 163.37,
+      "end": 163.85,
+      "text": "Okay."
+    },
+    {
+      "start": 163.84,
+      "end": 164.16,
+      "text": "Now,"
+    },
+    {
+      "start": 164.16,
+      "end": 164.24,
+      "text": "on"
+    },
+    {
+      "start": 164.25,
+      "end": 164.33,
+      "text": "to"
+    },
+    {
+      "start": 164.32,
+      "end": 164.4,
+      "text": "the"
+    },
+    {
+      "start": 164.41,
+      "end": 164.57,
+      "text": "real"
+    },
+    {
+      "start": 164.56,
+      "end": 164.8,
+      "text": "stuff."
+    },
+    {
+      "start": 166.02,
+      "end": 166.42,
+      "text": "Talking"
+    },
+    {
+      "start": 166.42,
+      "end": 166.58,
+      "text": "about"
+    },
+    {
+      "start": 166.58,
+      "end": 166.74,
+      "text": "the"
+    },
+    {
+      "start": 166.74,
+      "end": 167.38,
+      "text": "IETF"
+    },
+    {
+      "start": 167.38,
+      "end": 167.86,
+      "text": "or"
+    },
+    {
+      "start": 167.86,
+      "end": 168.1,
+      "text": "who"
+    },
+    {
+      "start": 168.1,
+      "end": 168.34,
+      "text": "gets"
+    },
+    {
+      "start": 168.34,
+      "end": 168.5,
+      "text": "to"
+    },
+    {
+      "start": 168.5,
+      "end": 168.82,
+      "text": "decide"
+    },
+    {
+      "start": 168.82,
+      "end": 169.14,
+      "text": "what"
+    },
+    {
+      "start": 169.14,
+      "end": 169.3,
+      "text": "the"
+    },
+    {
+      "start": 169.3,
+      "end": 169.78,
+      "text": "protocol"
+    },
+    {
+      "start": 169.78,
+      "end": 170.26,
+      "text": "actually"
+    },
+    {
+      "start": 170.26,
+      "end": 170.82,
+      "text": "is."
+    },
+    {
+      "start": 171.14,
+      "end": 171.62,
+      "text": "So,"
+    },
+    {
+      "start": 171.62,
+      "end": 171.78,
+      "text": "what"
+    },
+    {
+      "start": 171.78,
+      "end": 171.94,
+      "text": "is"
+    },
+    {
+      "start": 171.94,
+      "end": 172.1,
+      "text": "the"
+    },
+    {
+      "start": 172.1,
+      "end": 172.82,
+      "text": "IETF?"
+    },
+    {
+      "start": 172.82,
+      "end": 173.06,
+      "text": "It's"
+    },
+    {
+      "start": 173.06,
+      "end": 173.14,
+      "text": "the"
+    },
+    {
+      "start": 173.14,
+      "end": 173.46,
+      "text": "Internet"
+    },
+    {
+      "start": 173.46,
+      "end": 174.02,
+      "text": "Engineering"
+    },
+    {
+      "start": 174.02,
+      "end": 174.42,
+      "text": "Task"
+    },
+    {
+      "start": 174.42,
+      "end": 174.98,
+      "text": "Force."
+    },
+    {
+      "start": 175.7,
+      "end": 176.02,
+      "text": "It's"
+    },
+    {
+      "start": 176.02,
+      "end": 176.18,
+      "text": "the"
+    },
+    {
+      "start": 176.18,
+      "end": 176.5,
+      "text": "standards"
+    },
+    {
+      "start": 176.5,
+      "end": 176.82,
+      "text": "body"
+    },
+    {
+      "start": 176.82,
+      "end": 176.98,
+      "text": "for"
+    },
+    {
+      "start": 176.98,
+      "end": 177.06,
+      "text": "the"
+    },
+    {
+      "start": 177.06,
+      "end": 177.54,
+      "text": "Internet."
+    },
+    {
+      "start": 177.54,
+      "end": 177.7,
+      "text": "It"
+    },
+    {
+      "start": 177.7,
+      "end": 178.18,
+      "text": "standardized"
+    },
+    {
+      "start": 178.18,
+      "end": 178.42,
+      "text": "all"
+    },
+    {
+      "start": 178.42,
+      "end": 178.58,
+      "text": "the"
+    },
+    {
+      "start": 178.58,
+      "end": 178.9,
+      "text": "protocols"
+    },
+    {
+      "start": 178.9,
+      "end": 179.14,
+      "text": "that"
+    },
+    {
+      "start": 179.14,
+      "end": 179.3,
+      "text": "you"
+    },
+    {
+      "start": 179.3,
+      "end": 179.38,
+      "text": "know"
+    },
+    {
+      "start": 179.38,
+      "end": 179.54,
+      "text": "and"
+    },
+    {
+      "start": 179.54,
+      "end": 179.86,
+      "text": "love."
+    },
+    {
+      "start": 179.86,
+      "end": 180.1,
+      "text": "I'm"
+    },
+    {
+      "start": 180.1,
+      "end": 180.18,
+      "text": "sure"
+    },
+    {
+      "start": 180.18,
+      "end": 180.34,
+      "text": "that"
+    },
+    {
+      "start": 180.34,
+      "end": 180.58,
+      "text": "you're"
+    },
+    {
+      "start": 180.58,
+      "end": 180.9,
+      "text": "familiar"
+    },
+    {
+      "start": 180.9,
+      "end": 181.06,
+      "text": "with"
+    },
+    {
+      "start": 181.06,
+      "end": 181.14,
+      "text": "a"
+    },
+    {
+      "start": 181.14,
+      "end": 181.3,
+      "text": "lot"
+    },
+    {
+      "start": 181.3,
+      "end": 181.38,
+      "text": "of"
+    },
+    {
+      "start": 181.38,
+      "end": 181.54,
+      "text": "these."
+    },
+    {
+      "start": 181.75,
+      "end": 182.39,
+      "text": "SMTP"
+    },
+    {
+      "start": 182.4,
+      "end": 182.72,
+      "text": "for"
+    },
+    {
+      "start": 182.72,
+      "end": 183.2,
+      "text": "email,"
+    },
+    {
+      "start": 183.19,
+      "end": 183.91,
+      "text": "HTTP"
+    },
+    {
+      "start": 183.92,
+      "end": 184.16,
+      "text": "for"
+    },
+    {
+      "start": 184.16,
+      "end": 184.24,
+      "text": "the"
+    },
+    {
+      "start": 184.24,
+      "end": 184.8,
+      "text": "web,"
+    },
+    {
+      "start": 184.79,
+      "end": 185.51,
+      "text": "TLS,"
+    },
+    {
+      "start": 185.51,
+      "end": 185.59,
+      "text": "it"
+    },
+    {
+      "start": 185.59,
+      "end": 185.75,
+      "text": "gives"
+    },
+    {
+      "start": 185.75,
+      "end": 185.91,
+      "text": "you"
+    },
+    {
+      "start": 185.92,
+      "end": 186.08,
+      "text": "the"
+    },
+    {
+      "start": 186.08,
+      "end": 186.24,
+      "text": "little"
+    },
+    {
+      "start": 186.24,
+      "end": 186.56,
+      "text": "green"
+    },
+    {
+      "start": 186.56,
+      "end": 186.96,
+      "text": "lock"
+    },
+    {
+      "start": 186.96,
+      "end": 187.68,
+      "text": "that"
+    },
+    {
+      "start": 187.68,
+      "end": 188,
+      "text": "tells"
+    },
+    {
+      "start": 188,
+      "end": 188.16,
+      "text": "you"
+    },
+    {
+      "start": 188.16,
+      "end": 188.32,
+      "text": "that"
+    },
+    {
+      "start": 188.31,
+      "end": 188.47,
+      "text": "your"
+    },
+    {
+      "start": 188.47,
+      "end": 188.87,
+      "text": "website's"
+    },
+    {
+      "start": 188.88,
+      "end": 189.28,
+      "text": "secure,"
+    },
+    {
+      "start": 189.28,
+      "end": 190.08,
+      "text": "WebSockets,"
+    },
+    {
+      "start": 190.08,
+      "end": 190.72,
+      "text": "OAuth,"
+    },
+    {
+      "start": 190.72,
+      "end": 190.88,
+      "text": "and"
+    },
+    {
+      "start": 190.88,
+      "end": 191.44,
+      "text": "more."
+    },
+    {
+      "start": 192.64,
+      "end": 192.96,
+      "text": "To"
+    },
+    {
+      "start": 192.96,
+      "end": 193.12,
+      "text": "tell"
+    },
+    {
+      "start": 193.12,
+      "end": 193.2,
+      "text": "you"
+    },
+    {
+      "start": 193.19,
+      "end": 193.35,
+      "text": "a"
+    },
+    {
+      "start": 193.36,
+      "end": 193.44,
+      "text": "little"
+    },
+    {
+      "start": 193.44,
+      "end": 193.6,
+      "text": "bit"
+    },
+    {
+      "start": 193.59,
+      "end": 193.83,
+      "text": "about"
+    },
+    {
+      "start": 193.84,
+      "end": 194.08,
+      "text": "the"
+    },
+    {
+      "start": 194.08,
+      "end": 194.4,
+      "text": "vibe"
+    },
+    {
+      "start": 194.4,
+      "end": 194.56,
+      "text": "of"
+    },
+    {
+      "start": 194.56,
+      "end": 194.64,
+      "text": "the"
+    },
+    {
+      "start": 194.64,
+      "end": 195.28,
+      "text": "IETF,"
+    },
+    {
+      "start": 195.28,
+      "end": 195.44,
+      "text": "it's"
+    },
+    {
+      "start": 195.44,
+      "end": 195.52,
+      "text": "a"
+    },
+    {
+      "start": 195.51,
+      "end": 195.67,
+      "text": "pretty"
+    },
+    {
+      "start": 195.68,
+      "end": 196.08,
+      "text": "weird"
+    },
+    {
+      "start": 196.08,
+      "end": 197.04,
+      "text": "idiosyncratic"
+    },
+    {
+      "start": 197.13,
+      "end": 198.09,
+      "text": "organization."
+    },
+    {
+      "start": 198.17,
+      "end": 198.33,
+      "text": "I"
+    },
+    {
+      "start": 198.33,
+      "end": 198.49,
+      "text": "have"
+    },
+    {
+      "start": 198.49,
+      "end": 198.65,
+      "text": "a"
+    },
+    {
+      "start": 198.65,
+      "end": 198.81,
+      "text": "quote"
+    },
+    {
+      "start": 198.81,
+      "end": 199.05,
+      "text": "here"
+    },
+    {
+      "start": 199.05,
+      "end": 199.37,
+      "text": "from,"
+    },
+    {
+      "start": 199.61,
+      "end": 200.17,
+      "text": "Snarf"
+    },
+    {
+      "start": 200.17,
+      "end": 200.41,
+      "text": "that"
+    },
+    {
+      "start": 200.41,
+      "end": 200.49,
+      "text": "I"
+    },
+    {
+      "start": 200.49,
+      "end": 200.65,
+      "text": "think"
+    },
+    {
+      "start": 200.65,
+      "end": 201.05,
+      "text": "captures"
+    },
+    {
+      "start": 201.05,
+      "end": 201.29,
+      "text": "it"
+    },
+    {
+      "start": 201.29,
+      "end": 201.45,
+      "text": "pretty"
+    },
+    {
+      "start": 201.45,
+      "end": 201.93,
+      "text": "well."
+    },
+    {
+      "start": 201.93,
+      "end": 202.17,
+      "text": "He"
+    },
+    {
+      "start": 202.17,
+      "end": 202.49,
+      "text": "said,"
+    },
+    {
+      "start": 202.49,
+      "end": 202.89,
+      "text": "standard"
+    },
+    {
+      "start": 203.13,
+      "end": 203.45,
+      "text": "standards"
+    },
+    {
+      "start": 203.45,
+      "end": 204.01,
+      "text": "bodies"
+    },
+    {
+      "start": 204.01,
+      "end": 204.33,
+      "text": "or"
+    },
+    {
+      "start": 204.33,
+      "end": 205.05,
+      "text": "bureaucracy"
+    },
+    {
+      "start": 205.05,
+      "end": 205.29,
+      "text": "for"
+    },
+    {
+      "start": 205.29,
+      "end": 205.85,
+      "text": "good,"
+    },
+    {
+      "start": 205.93,
+      "end": 206.09,
+      "text": "which"
+    },
+    {
+      "start": 206.09,
+      "end": 206.25,
+      "text": "I"
+    },
+    {
+      "start": 206.25,
+      "end": 206.49,
+      "text": "think"
+    },
+    {
+      "start": 206.49,
+      "end": 206.89,
+      "text": "sums"
+    },
+    {
+      "start": 206.89,
+      "end": 206.97,
+      "text": "it"
+    },
+    {
+      "start": 206.97,
+      "end": 207.29,
+      "text": "up."
+    },
+    {
+      "start": 207.29,
+      "end": 207.77,
+      "text": "It's,"
+    },
+    {
+      "start": 208.01,
+      "end": 208.33,
+      "text": "pretty"
+    },
+    {
+      "start": 208.33,
+      "end": 209.05,
+      "text": "bureaucratic."
+    },
+    {
+      "start": 209.05,
+      "end": 209.21,
+      "text": "It's"
+    },
+    {
+      "start": 209.21,
+      "end": 209.37,
+      "text": "pretty"
+    },
+    {
+      "start": 209.37,
+      "end": 209.93,
+      "text": "pedantic,"
+    },
+    {
+      "start": 210.07,
+      "end": 210.31,
+      "text": "But"
+    },
+    {
+      "start": 210.31,
+      "end": 210.47,
+      "text": "it's"
+    },
+    {
+      "start": 210.47,
+      "end": 210.79,
+      "text": "ultimately"
+    },
+    {
+      "start": 210.79,
+      "end": 211.03,
+      "text": "a"
+    },
+    {
+      "start": 211.03,
+      "end": 211.27,
+      "text": "very"
+    },
+    {
+      "start": 211.28,
+      "end": 211.92,
+      "text": "idealistic"
+    },
+    {
+      "start": 211.91,
+      "end": 212.79,
+      "text": "organization"
+    },
+    {
+      "start": 212.96,
+      "end": 213.28,
+      "text": "and"
+    },
+    {
+      "start": 213.28,
+      "end": 213.52,
+      "text": "it's"
+    },
+    {
+      "start": 213.51,
+      "end": 213.59,
+      "text": "a"
+    },
+    {
+      "start": 213.59,
+      "end": 214.07,
+      "text": "very"
+    },
+    {
+      "start": 214.47,
+      "end": 214.95,
+      "text": "neutral"
+    },
+    {
+      "start": 214.96,
+      "end": 215.44,
+      "text": "credible"
+    },
+    {
+      "start": 215.44,
+      "end": 216.08,
+      "text": "body,"
+    },
+    {
+      "start": 216.07,
+      "end": 216.23,
+      "text": "then"
+    },
+    {
+      "start": 216.24,
+      "end": 216.4,
+      "text": "they"
+    },
+    {
+      "start": 216.39,
+      "end": 216.55,
+      "text": "do"
+    },
+    {
+      "start": 216.56,
+      "end": 216.72,
+      "text": "a"
+    },
+    {
+      "start": 216.72,
+      "end": 216.88,
+      "text": "very"
+    },
+    {
+      "start": 216.88,
+      "end": 217.12,
+      "text": "good"
+    },
+    {
+      "start": 217.11,
+      "end": 217.51,
+      "text": "job"
+    },
+    {
+      "start": 217.51,
+      "end": 217.83,
+      "text": "sort"
+    },
+    {
+      "start": 217.83,
+      "end": 217.99,
+      "text": "of"
+    },
+    {
+      "start": 218,
+      "end": 218.48,
+      "text": "stewarding"
+    },
+    {
+      "start": 218.47,
+      "end": 218.71,
+      "text": "and"
+    },
+    {
+      "start": 218.72,
+      "end": 219.12,
+      "text": "owning"
+    },
+    {
+      "start": 219.11,
+      "end": 219.43,
+      "text": "these"
+    },
+    {
+      "start": 219.44,
+      "end": 219.68,
+      "text": "sorts"
+    },
+    {
+      "start": 219.68,
+      "end": 219.76,
+      "text": "of"
+    },
+    {
+      "start": 219.75,
+      "end": 220.07,
+      "text": "internet"
+    },
+    {
+      "start": 220.07,
+      "end": 220.95,
+      "text": "protocols."
+    },
+    {
+      "start": 221.11,
+      "end": 221.43,
+      "text": "So,"
+    },
+    {
+      "start": 221.44,
+      "end": 221.52,
+      "text": "a"
+    },
+    {
+      "start": 221.51,
+      "end": 221.75,
+      "text": "mix"
+    },
+    {
+      "start": 221.75,
+      "end": 221.83,
+      "text": "of"
+    },
+    {
+      "start": 221.83,
+      "end": 222.63,
+      "text": "institutional,"
+    },
+    {
+      "start": 222.63,
+      "end": 222.71,
+      "text": "but"
+    },
+    {
+      "start": 222.72,
+      "end": 222.88,
+      "text": "it's"
+    },
+    {
+      "start": 222.88,
+      "end": 223.04,
+      "text": "also"
+    },
+    {
+      "start": 223.03,
+      "end": 223.75,
+      "text": "grass"
+    },
+    {
+      "start": 223.35,
+      "end": 223.67,
+      "text": "roots."
+    },
+    {
+      "start": 223.67,
+      "end": 223.83,
+      "text": "You"
+    },
+    {
+      "start": 223.83,
+      "end": 223.91,
+      "text": "kind"
+    },
+    {
+      "start": 223.91,
+      "end": 223.99,
+      "text": "of"
+    },
+    {
+      "start": 223.99,
+      "end": 224.15,
+      "text": "have"
+    },
+    {
+      "start": 224.15,
+      "end": 224.39,
+      "text": "like"
+    },
+    {
+      "start": 224.39,
+      "end": 224.47,
+      "text": "a"
+    },
+    {
+      "start": 224.47,
+      "end": 224.55,
+      "text": "lot"
+    },
+    {
+      "start": 224.55,
+      "end": 224.71,
+      "text": "of"
+    },
+    {
+      "start": 224.71,
+      "end": 224.95,
+      "text": "old"
+    },
+    {
+      "start": 224.95,
+      "end": 225.27,
+      "text": "Internet"
+    },
+    {
+      "start": 225.27,
+      "end": 225.59,
+      "text": "heads"
+    },
+    {
+      "start": 225.59,
+      "end": 225.83,
+      "text": "there."
+    },
+    {
+      "start": 225.83,
+      "end": 225.99,
+      "text": "You"
+    },
+    {
+      "start": 225.99,
+      "end": 226.15,
+      "text": "have"
+    },
+    {
+      "start": 226.15,
+      "end": 226.71,
+      "text": "activists,"
+    },
+    {
+      "start": 226.71,
+      "end": 226.79,
+      "text": "you"
+    },
+    {
+      "start": 226.79,
+      "end": 227.27,
+      "text": "have"
+    },
+    {
+      "start": 227.35,
+      "end": 227.91,
+      "text": "academics"
+    },
+    {
+      "start": 227.91,
+      "end": 228.07,
+      "text": "and"
+    },
+    {
+      "start": 228.07,
+      "end": 228.71,
+      "text": "researchers,"
+    },
+    {
+      "start": 228.71,
+      "end": 228.79,
+      "text": "you"
+    },
+    {
+      "start": 228.79,
+      "end": 228.95,
+      "text": "also"
+    },
+    {
+      "start": 228.95,
+      "end": 229.11,
+      "text": "have"
+    },
+    {
+      "start": 229.11,
+      "end": 229.35,
+      "text": "folks"
+    },
+    {
+      "start": 229.35,
+      "end": 229.51,
+      "text": "from"
+    },
+    {
+      "start": 229.51,
+      "end": 229.59,
+      "text": "the"
+    },
+    {
+      "start": 229.59,
+      "end": 229.75,
+      "text": "big"
+    },
+    {
+      "start": 229.75,
+      "end": 229.99,
+      "text": "tech"
+    },
+    {
+      "start": 229.99,
+      "end": 230.47,
+      "text": "companies,"
+    },
+    {
+      "start": 230.47,
+      "end": 230.71,
+      "text": "Google"
+    },
+    {
+      "start": 230.71,
+      "end": 230.95,
+      "text": "and"
+    },
+    {
+      "start": 230.95,
+      "end": 231.83,
+      "text": "Cloudflare,"
+    },
+    {
+      "start": 231.99,
+      "end": 232.39,
+      "text": "and"
+    },
+    {
+      "start": 232.39,
+      "end": 233.03,
+      "text": "others."
+    },
+    {
+      "start": 233.99,
+      "end": 234.15,
+      "text": "And"
+    },
+    {
+      "start": 234.15,
+      "end": 234.39,
+      "text": "that"
+    },
+    {
+      "start": 234.39,
+      "end": 234.63,
+      "text": "also"
+    },
+    {
+      "start": 234.63,
+      "end": 234.79,
+      "text": "gives"
+    },
+    {
+      "start": 234.79,
+      "end": 235.03,
+      "text": "it"
+    },
+    {
+      "start": 235.03,
+      "end": 235.19,
+      "text": "this"
+    },
+    {
+      "start": 235.19,
+      "end": 235.35,
+      "text": "mix"
+    },
+    {
+      "start": 235.35,
+      "end": 235.59,
+      "text": "of"
+    },
+    {
+      "start": 235.59,
+      "end": 236.15,
+      "text": "idealism"
+    },
+    {
+      "start": 236.15,
+      "end": 236.31,
+      "text": "and"
+    },
+    {
+      "start": 236.31,
+      "end": 237.03,
+      "text": "pragmatism."
+    },
+    {
+      "start": 237.03,
+      "end": 237.59,
+      "text": "People"
+    },
+    {
+      "start": 237.56,
+      "end": 237.8,
+      "text": "conversations"
+    },
+    {
+      "start": 237.79,
+      "end": 238.19,
+      "text": "about"
+    },
+    {
+      "start": 238.19,
+      "end": 238.43,
+      "text": "keeping"
+    },
+    {
+      "start": 238.44,
+      "end": 238.68,
+      "text": "the"
+    },
+    {
+      "start": 238.67,
+      "end": 238.91,
+      "text": "internet"
+    },
+    {
+      "start": 238.91,
+      "end": 239.95,
+      "text": "decentralized,"
+    },
+    {
+      "start": 239.95,
+      "end": 240.11,
+      "text": "but"
+    },
+    {
+      "start": 240.11,
+      "end": 240.35,
+      "text": "also"
+    },
+    {
+      "start": 240.35,
+      "end": 240.67,
+      "text": "they"
+    },
+    {
+      "start": 240.67,
+      "end": 240.83,
+      "text": "care"
+    },
+    {
+      "start": 240.83,
+      "end": 240.99,
+      "text": "a"
+    },
+    {
+      "start": 241,
+      "end": 241.08,
+      "text": "lot"
+    },
+    {
+      "start": 241.07,
+      "end": 241.23,
+      "text": "about"
+    },
+    {
+      "start": 241.23,
+      "end": 241.39,
+      "text": "the"
+    },
+    {
+      "start": 241.39,
+      "end": 241.71,
+      "text": "internet"
+    },
+    {
+      "start": 241.72,
+      "end": 242.2,
+      "text": "working"
+    },
+    {
+      "start": 242.19,
+      "end": 242.67,
+      "text": "well."
+    },
+    {
+      "start": 242.91,
+      "end": 243.23,
+      "text": "And"
+    },
+    {
+      "start": 243.23,
+      "end": 243.47,
+      "text": "so,"
+    },
+    {
+      "start": 243.47,
+      "end": 243.63,
+      "text": "have"
+    },
+    {
+      "start": 243.63,
+      "end": 243.79,
+      "text": "this"
+    },
+    {
+      "start": 243.79,
+      "end": 244.03,
+      "text": "very"
+    },
+    {
+      "start": 244.03,
+      "end": 244.59,
+      "text": "pragmatic"
+    },
+    {
+      "start": 244.59,
+      "end": 245.23,
+      "text": "approach."
+    },
+    {
+      "start": 245.72,
+      "end": 246.36,
+      "text": "The"
+    },
+    {
+      "start": 246.59,
+      "end": 246.83,
+      "text": "kind"
+    },
+    {
+      "start": 246.83,
+      "end": 246.99,
+      "text": "of"
+    },
+    {
+      "start": 247,
+      "end": 247.4,
+      "text": "motto"
+    },
+    {
+      "start": 247.39,
+      "end": 247.71,
+      "text": "there"
+    },
+    {
+      "start": 247.72,
+      "end": 248.04,
+      "text": "is"
+    },
+    {
+      "start": 248.03,
+      "end": 248.59,
+      "text": "that"
+    },
+    {
+      "start": 248.75,
+      "end": 249.23,
+      "text": "decisions"
+    },
+    {
+      "start": 249.23,
+      "end": 249.47,
+      "text": "are"
+    },
+    {
+      "start": 249.47,
+      "end": 249.63,
+      "text": "made"
+    },
+    {
+      "start": 249.63,
+      "end": 249.79,
+      "text": "by"
+    },
+    {
+      "start": 249.79,
+      "end": 250.19,
+      "text": "rough"
+    },
+    {
+      "start": 250.19,
+      "end": 250.59,
+      "text": "consensus"
+    },
+    {
+      "start": 250.59,
+      "end": 250.91,
+      "text": "and"
+    },
+    {
+      "start": 250.91,
+      "end": 251.15,
+      "text": "working"
+    },
+    {
+      "start": 251.16,
+      "end": 251.48,
+      "text": "code,"
+    },
+    {
+      "start": 251.78,
+      "end": 252.1,
+      "text": "which"
+    },
+    {
+      "start": 252.1,
+      "end": 252.26,
+      "text": "I"
+    },
+    {
+      "start": 252.26,
+      "end": 252.42,
+      "text": "think"
+    },
+    {
+      "start": 252.42,
+      "end": 252.66,
+      "text": "actually"
+    },
+    {
+      "start": 252.66,
+      "end": 252.98,
+      "text": "gives"
+    },
+    {
+      "start": 252.98,
+      "end": 253.14,
+      "text": "a"
+    },
+    {
+      "start": 253.14,
+      "end": 253.3,
+      "text": "good"
+    },
+    {
+      "start": 253.3,
+      "end": 253.46,
+      "text": "sense"
+    },
+    {
+      "start": 253.46,
+      "end": 253.62,
+      "text": "of"
+    },
+    {
+      "start": 253.62,
+      "end": 253.78,
+      "text": "that"
+    },
+    {
+      "start": 253.78,
+      "end": 254.5,
+      "text": "idealism"
+    },
+    {
+      "start": 254.5,
+      "end": 254.82,
+      "text": "and"
+    },
+    {
+      "start": 254.82,
+      "end": 255.54,
+      "text": "pragmatism."
+    },
+    {
+      "start": 255.54,
+      "end": 255.62,
+      "text": "They"
+    },
+    {
+      "start": 255.62,
+      "end": 255.86,
+      "text": "wanna"
+    },
+    {
+      "start": 255.86,
+      "end": 256.02,
+      "text": "see"
+    },
+    {
+      "start": 257.14,
+      "end": 257.3,
+      "text": "wanna"
+    },
+    {
+      "start": 257.3,
+      "end": 257.46,
+      "text": "get"
+    },
+    {
+      "start": 257.7,
+      "end": 257.78,
+      "text": "of"
+    },
+    {
+      "start": 258.74,
+      "end": 259.14,
+      "text": "room"
+    },
+    {
+      "start": 259.14,
+      "end": 259.62,
+      "text": "and"
+    },
+    {
+      "start": 259.62,
+      "end": 260.1,
+      "text": "have"
+    },
+    {
+      "start": 260.5,
+      "end": 260.98,
+      "text": "agreement"
+    },
+    {
+      "start": 261.14,
+      "end": 261.62,
+      "text": "it."
+    },
+    {
+      "start": 261.86,
+      "end": 262.18,
+      "text": "It's"
+    },
+    {
+      "start": 262.18,
+      "end": 262.42,
+      "text": "open"
+    },
+    {
+      "start": 262.42,
+      "end": 263.14,
+      "text": "membership."
+    },
+    {
+      "start": 263.14,
+      "end": 263.46,
+      "text": "Anybody"
+    },
+    {
+      "start": 263.46,
+      "end": 263.78,
+      "text": "can"
+    },
+    {
+      "start": 263.78,
+      "end": 264.02,
+      "text": "join."
+    },
+    {
+      "start": 264.69,
+      "end": 264.93,
+      "text": "You"
+    },
+    {
+      "start": 264.93,
+      "end": 265.09,
+      "text": "don't"
+    },
+    {
+      "start": 265.08,
+      "end": 265.24,
+      "text": "need"
+    },
+    {
+      "start": 265.25,
+      "end": 265.41,
+      "text": "to"
+    },
+    {
+      "start": 265.4,
+      "end": 265.48,
+      "text": "pay"
+    },
+    {
+      "start": 265.49,
+      "end": 265.81,
+      "text": "money"
+    },
+    {
+      "start": 265.81,
+      "end": 265.97,
+      "text": "to"
+    },
+    {
+      "start": 265.96,
+      "end": 266.28,
+      "text": "join."
+    },
+    {
+      "start": 266.29,
+      "end": 266.37,
+      "text": "You"
+    },
+    {
+      "start": 266.37,
+      "end": 266.53,
+      "text": "can"
+    },
+    {
+      "start": 266.52,
+      "end": 266.6,
+      "text": "just"
+    },
+    {
+      "start": 266.6,
+      "end": 266.76,
+      "text": "hop"
+    },
+    {
+      "start": 266.76,
+      "end": 266.92,
+      "text": "in"
+    },
+    {
+      "start": 266.93,
+      "end": 267.01,
+      "text": "the"
+    },
+    {
+      "start": 267,
+      "end": 267.24,
+      "text": "mailing"
+    },
+    {
+      "start": 267.25,
+      "end": 267.57,
+      "text": "list,"
+    },
+    {
+      "start": 267.56,
+      "end": 267.72,
+      "text": "start"
+    },
+    {
+      "start": 267.73,
+      "end": 268.29,
+      "text": "participating."
+    },
+    {
+      "start": 268.29,
+      "end": 268.37,
+      "text": "You"
+    },
+    {
+      "start": 268.37,
+      "end": 268.45,
+      "text": "can"
+    },
+    {
+      "start": 268.44,
+      "end": 268.6,
+      "text": "show"
+    },
+    {
+      "start": 268.6,
+      "end": 268.68,
+      "text": "up"
+    },
+    {
+      "start": 268.69,
+      "end": 268.85,
+      "text": "to"
+    },
+    {
+      "start": 268.85,
+      "end": 269.09,
+      "text": "meetings"
+    },
+    {
+      "start": 269.08,
+      "end": 269.24,
+      "text": "and"
+    },
+    {
+      "start": 269.25,
+      "end": 269.41,
+      "text": "start"
+    },
+    {
+      "start": 269.4,
+      "end": 270.2,
+      "text": "participating."
+    },
+    {
+      "start": 270.6,
+      "end": 271.08,
+      "text": "And"
+    },
+    {
+      "start": 271.25,
+      "end": 271.57,
+      "text": "companies"
+    },
+    {
+      "start": 271.56,
+      "end": 271.8,
+      "text": "are"
+    },
+    {
+      "start": 271.81,
+      "end": 272.05,
+      "text": "not"
+    },
+    {
+      "start": 272.04,
+      "end": 272.28,
+      "text": "members"
+    },
+    {
+      "start": 272.29,
+      "end": 272.45,
+      "text": "of"
+    },
+    {
+      "start": 272.44,
+      "end": 272.68,
+      "text": "it."
+    },
+    {
+      "start": 272.69,
+      "end": 273.25,
+      "text": "Individuals"
+    },
+    {
+      "start": 273.25,
+      "end": 273.41,
+      "text": "are"
+    },
+    {
+      "start": 273.4,
+      "end": 273.8,
+      "text": "members."
+    },
+    {
+      "start": 273.81,
+      "end": 274.05,
+      "text": "And"
+    },
+    {
+      "start": 274.04,
+      "end": 274.2,
+      "text": "I"
+    },
+    {
+      "start": 274.2,
+      "end": 274.36,
+      "text": "put"
+    },
+    {
+      "start": 274.37,
+      "end": 274.77,
+      "text": "kind"
+    },
+    {
+      "start": 274.76,
+      "end": 274.92,
+      "text": "of"
+    },
+    {
+      "start": 274.93,
+      "end": 275.09,
+      "text": "here"
+    },
+    {
+      "start": 275.08,
+      "end": 275.56,
+      "text": "because"
+    },
+    {
+      "start": 275.56,
+      "end": 276.12,
+      "text": "most"
+    },
+    {
+      "start": 276.13,
+      "end": 276.37,
+      "text": "people"
+    },
+    {
+      "start": 276.37,
+      "end": 276.53,
+      "text": "have"
+    },
+    {
+      "start": 276.52,
+      "end": 276.68,
+      "text": "an"
+    },
+    {
+      "start": 276.69,
+      "end": 277.17,
+      "text": "affiliation"
+    },
+    {
+      "start": 277.16,
+      "end": 277.32,
+      "text": "with"
+    },
+    {
+      "start": 277.32,
+      "end": 277.48,
+      "text": "the"
+    },
+    {
+      "start": 277.49,
+      "end": 277.73,
+      "text": "company"
+    },
+    {
+      "start": 277.73,
+      "end": 278.05,
+      "text": "and"
+    },
+    {
+      "start": 278.04,
+      "end": 278.28,
+      "text": "it's"
+    },
+    {
+      "start": 278.29,
+      "end": 278.45,
+      "text": "like"
+    },
+    {
+      "start": 278.44,
+      "end": 278.68,
+      "text": "they"
+    },
+    {
+      "start": 278.69,
+      "end": 278.93,
+      "text": "kinda"
+    },
+    {
+      "start": 278.93,
+      "end": 279.33,
+      "text": "wear"
+    },
+    {
+      "start": 279.57,
+      "end": 279.73,
+      "text": "it."
+    },
+    {
+      "start": 279.73,
+      "end": 279.89,
+      "text": "It's"
+    },
+    {
+      "start": 279.89,
+      "end": 280.05,
+      "text": "pretty"
+    },
+    {
+      "start": 280.05,
+      "end": 280.29,
+      "text": "clear"
+    },
+    {
+      "start": 280.29,
+      "end": 280.61,
+      "text": "that"
+    },
+    {
+      "start": 280.61,
+      "end": 280.85,
+      "text": "they"
+    },
+    {
+      "start": 280.85,
+      "end": 281.01,
+      "text": "are"
+    },
+    {
+      "start": 281.01,
+      "end": 281.41,
+      "text": "affiliated"
+    },
+    {
+      "start": 281.41,
+      "end": 281.65,
+      "text": "with"
+    },
+    {
+      "start": 281.65,
+      "end": 282.29,
+      "text": "companies,"
+    },
+    {
+      "start": 283.17,
+      "end": 283.41,
+      "text": "but"
+    },
+    {
+      "start": 283.41,
+      "end": 283.57,
+      "text": "it"
+    },
+    {
+      "start": 283.57,
+      "end": 283.73,
+      "text": "it"
+    },
+    {
+      "start": 283.73,
+      "end": 283.89,
+      "text": "is"
+    },
+    {
+      "start": 283.89,
+      "end": 284.13,
+      "text": "still"
+    },
+    {
+      "start": 284.29,
+      "end": 284.45,
+      "text": "it"
+    },
+    {
+      "start": 284.45,
+      "end": 284.69,
+      "text": "kinda"
+    },
+    {
+      "start": 284.69,
+      "end": 284.93,
+      "text": "gets"
+    },
+    {
+      "start": 284.93,
+      "end": 285.17,
+      "text": "at"
+    },
+    {
+      "start": 285.17,
+      "end": 285.57,
+      "text": "their"
+    },
+    {
+      "start": 285.57,
+      "end": 285.81,
+      "text": "their"
+    },
+    {
+      "start": 285.81,
+      "end": 286.53,
+      "text": "ethos,"
+    },
+    {
+      "start": 286.69,
+      "end": 286.93,
+      "text": "in"
+    },
+    {
+      "start": 286.93,
+      "end": 287.09,
+      "text": "a"
+    },
+    {
+      "start": 287.09,
+      "end": 287.33,
+      "text": "way,"
+    },
+    {
+      "start": 287.33,
+      "end": 287.41,
+      "text": "which"
+    },
+    {
+      "start": 287.41,
+      "end": 287.57,
+      "text": "is"
+    },
+    {
+      "start": 287.57,
+      "end": 287.73,
+      "text": "that"
+    },
+    {
+      "start": 287.73,
+      "end": 287.97,
+      "text": "these"
+    },
+    {
+      "start": 287.97,
+      "end": 288.13,
+      "text": "are"
+    },
+    {
+      "start": 288.13,
+      "end": 288.37,
+      "text": "these"
+    },
+    {
+      "start": 288.37,
+      "end": 288.53,
+      "text": "are"
+    },
+    {
+      "start": 288.53,
+      "end": 288.93,
+      "text": "engineers"
+    },
+    {
+      "start": 288.93,
+      "end": 289.25,
+      "text": "coming"
+    },
+    {
+      "start": 289.25,
+      "end": 289.65,
+      "text": "together"
+    },
+    {
+      "start": 289.65,
+      "end": 290.05,
+      "text": "trying"
+    },
+    {
+      "start": 290.05,
+      "end": 290.13,
+      "text": "to"
+    },
+    {
+      "start": 290.13,
+      "end": 290.37,
+      "text": "reach"
+    },
+    {
+      "start": 290.37,
+      "end": 290.69,
+      "text": "consensus"
+    },
+    {
+      "start": 290.69,
+      "end": 291.01,
+      "text": "on"
+    },
+    {
+      "start": 291.01,
+      "end": 291.41,
+      "text": "protocols."
+    },
+    {
+      "start": 292.04,
+      "end": 292.36,
+      "text": "So"
+    },
+    {
+      "start": 292.37,
+      "end": 292.53,
+      "text": "the"
+    },
+    {
+      "start": 292.52,
+      "end": 292.84,
+      "text": "exciting"
+    },
+    {
+      "start": 292.85,
+      "end": 293.09,
+      "text": "news"
+    },
+    {
+      "start": 293.08,
+      "end": 293.24,
+      "text": "is"
+    },
+    {
+      "start": 293.25,
+      "end": 293.41,
+      "text": "we"
+    },
+    {
+      "start": 293.4,
+      "end": 293.48,
+      "text": "have"
+    },
+    {
+      "start": 293.49,
+      "end": 293.65,
+      "text": "a"
+    },
+    {
+      "start": 293.64,
+      "end": 293.88,
+      "text": "working"
+    },
+    {
+      "start": 293.88,
+      "end": 294.04,
+      "text": "group"
+    },
+    {
+      "start": 294.04,
+      "end": 294.36,
+      "text": "at"
+    },
+    {
+      "start": 294.37,
+      "end": 294.45,
+      "text": "the"
+    },
+    {
+      "start": 294.44,
+      "end": 295.32,
+      "text": "IETF."
+    },
+    {
+      "start": 295.32,
+      "end": 295.88,
+      "text": "Also,"
+    },
+    {
+      "start": 303,
+      "end": 303.48,
+      "text": "kudos"
+    },
+    {
+      "start": 303.49,
+      "end": 303.89,
+      "text": "to"
+    },
+    {
+      "start": 303.88,
+      "end": 304.28,
+      "text": "Brian"
+    },
+    {
+      "start": 304.28,
+      "end": 304.52,
+      "text": "on"
+    },
+    {
+      "start": 304.52,
+      "end": 304.68,
+      "text": "that."
+    },
+    {
+      "start": 304.69,
+      "end": 304.93,
+      "text": "Brian"
+    },
+    {
+      "start": 304.93,
+      "end": 305.25,
+      "text": "really"
+    },
+    {
+      "start": 305.25,
+      "end": 305.41,
+      "text": "led"
+    },
+    {
+      "start": 305.4,
+      "end": 305.56,
+      "text": "up"
+    },
+    {
+      "start": 305.56,
+      "end": 305.72,
+      "text": "the"
+    },
+    {
+      "start": 305.72,
+      "end": 306.04,
+      "text": "standards"
+    },
+    {
+      "start": 306.04,
+      "end": 306.28,
+      "text": "work."
+    },
+    {
+      "start": 306.36,
+      "end": 306.76,
+      "text": "All"
+    },
+    {
+      "start": 306.76,
+      "end": 307.16,
+      "text": "honesty,"
+    },
+    {
+      "start": 307.16,
+      "end": 307.24,
+      "text": "he"
+    },
+    {
+      "start": 307.24,
+      "end": 307.4,
+      "text": "should"
+    },
+    {
+      "start": 307.4,
+      "end": 307.48,
+      "text": "be"
+    },
+    {
+      "start": 307.48,
+      "end": 307.64,
+      "text": "the"
+    },
+    {
+      "start": 307.64,
+      "end": 307.8,
+      "text": "one"
+    },
+    {
+      "start": 307.8,
+      "end": 307.96,
+      "text": "up"
+    },
+    {
+      "start": 307.96,
+      "end": 308.04,
+      "text": "here"
+    },
+    {
+      "start": 308.04,
+      "end": 308.44,
+      "text": "presenting"
+    },
+    {
+      "start": 308.44,
+      "end": 308.6,
+      "text": "all"
+    },
+    {
+      "start": 308.6,
+      "end": 308.76,
+      "text": "of"
+    },
+    {
+      "start": 308.76,
+      "end": 308.92,
+      "text": "this."
+    },
+    {
+      "start": 308.92,
+      "end": 309.16,
+      "text": "He's"
+    },
+    {
+      "start": 309.16,
+      "end": 309.24,
+      "text": "just"
+    },
+    {
+      "start": 309.24,
+      "end": 309.4,
+      "text": "done"
+    },
+    {
+      "start": 309.4,
+      "end": 309.56,
+      "text": "an"
+    },
+    {
+      "start": 309.56,
+      "end": 309.96,
+      "text": "incredible"
+    },
+    {
+      "start": 309.96,
+      "end": 310.12,
+      "text": "job"
+    },
+    {
+      "start": 310.12,
+      "end": 310.36,
+      "text": "at"
+    },
+    {
+      "start": 310.36,
+      "end": 310.76,
+      "text": "that."
+    },
+    {
+      "start": 311.32,
+      "end": 311.56,
+      "text": "The"
+    },
+    {
+      "start": 311.56,
+      "end": 311.88,
+      "text": "working"
+    },
+    {
+      "start": 311.88,
+      "end": 312.2,
+      "text": "group"
+    },
+    {
+      "start": 312.2,
+      "end": 312.44,
+      "text": "is"
+    },
+    {
+      "start": 312.44,
+      "end": 312.76,
+      "text": "called"
+    },
+    {
+      "start": 312.76,
+      "end": 313.48,
+      "text": "authenticated"
+    },
+    {
+      "start": 313.48,
+      "end": 313.96,
+      "text": "transfer"
+    },
+    {
+      "start": 313.96,
+      "end": 314.28,
+      "text": "or"
+    },
+    {
+      "start": 314.28,
+      "end": 315.08,
+      "text": "ATP."
+    },
+    {
+      "start": 315.48,
+      "end": 315.8,
+      "text": "This"
+    },
+    {
+      "start": 315.8,
+      "end": 315.96,
+      "text": "is"
+    },
+    {
+      "start": 315.96,
+      "end": 316.12,
+      "text": "the"
+    },
+    {
+      "start": 316.12,
+      "end": 316.44,
+      "text": "URL"
+    },
+    {
+      "start": 316.44,
+      "end": 316.76,
+      "text": "for"
+    },
+    {
+      "start": 316.76,
+      "end": 317,
+      "text": "it."
+    },
+    {
+      "start": 318.68,
+      "end": 319,
+      "text": "The"
+    },
+    {
+      "start": 319,
+      "end": 319.4,
+      "text": "responsible"
+    },
+    {
+      "start": 319.39,
+      "end": 319.71,
+      "text": "area"
+    },
+    {
+      "start": 319.71,
+      "end": 320.03,
+      "text": "director"
+    },
+    {
+      "start": 320.04,
+      "end": 320.28,
+      "text": "is"
+    },
+    {
+      "start": 320.27,
+      "end": 320.59,
+      "text": "Andy"
+    },
+    {
+      "start": 320.6,
+      "end": 321,
+      "text": "Newton."
+    },
+    {
+      "start": 321,
+      "end": 321.16,
+      "text": "The"
+    },
+    {
+      "start": 321.15,
+      "end": 321.31,
+      "text": "working"
+    },
+    {
+      "start": 321.31,
+      "end": 321.55,
+      "text": "group"
+    },
+    {
+      "start": 321.56,
+      "end": 321.8,
+      "text": "chairs"
+    },
+    {
+      "start": 321.79,
+      "end": 321.95,
+      "text": "are"
+    },
+    {
+      "start": 321.95,
+      "end": 322.19,
+      "text": "Shu"
+    },
+    {
+      "start": 322.19,
+      "end": 322.35,
+      "text": "Ping"
+    },
+    {
+      "start": 322.36,
+      "end": 322.6,
+      "text": "and"
+    },
+    {
+      "start": 322.68,
+      "end": 323,
+      "text": "Shu"
+    },
+    {
+      "start": 323,
+      "end": 323.16,
+      "text": "Ping"
+    },
+    {
+      "start": 323.15,
+      "end": 323.55,
+      "text": "Peng"
+    },
+    {
+      "start": 323.56,
+      "end": 324.2,
+      "text": "and"
+    },
+    {
+      "start": 324.19,
+      "end": 324.75,
+      "text": "Mallory"
+    },
+    {
+      "start": 324.75,
+      "end": 325.47,
+      "text": "Nodel."
+    },
+    {
+      "start": 325.48,
+      "end": 325.8,
+      "text": "Brian"
+    },
+    {
+      "start": 325.79,
+      "end": 325.95,
+      "text": "and"
+    },
+    {
+      "start": 325.95,
+      "end": 326.11,
+      "text": "I"
+    },
+    {
+      "start": 326.12,
+      "end": 326.28,
+      "text": "got"
+    },
+    {
+      "start": 326.27,
+      "end": 326.35,
+      "text": "the"
+    },
+    {
+      "start": 326.36,
+      "end": 326.6,
+      "text": "chance"
+    },
+    {
+      "start": 326.6,
+      "end": 326.68,
+      "text": "to"
+    },
+    {
+      "start": 326.68,
+      "end": 327,
+      "text": "chat"
+    },
+    {
+      "start": 327,
+      "end": 327.16,
+      "text": "with"
+    },
+    {
+      "start": 327.15,
+      "end": 327.31,
+      "text": "all"
+    },
+    {
+      "start": 327.31,
+      "end": 327.39,
+      "text": "three"
+    },
+    {
+      "start": 327.39,
+      "end": 327.55,
+      "text": "of"
+    },
+    {
+      "start": 327.56,
+      "end": 327.72,
+      "text": "these"
+    },
+    {
+      "start": 327.71,
+      "end": 328.27,
+      "text": "folks"
+    },
+    {
+      "start": 328.36,
+      "end": 328.84,
+      "text": "earlier"
+    },
+    {
+      "start": 328.83,
+      "end": 329.15,
+      "text": "this"
+    },
+    {
+      "start": 329.15,
+      "end": 329.63,
+      "text": "week."
+    },
+    {
+      "start": 329.79,
+      "end": 330.19,
+      "text": "Generally,"
+    },
+    {
+      "start": 330.19,
+      "end": 330.51,
+      "text": "got"
+    },
+    {
+      "start": 330.51,
+      "end": 330.75,
+      "text": "very"
+    },
+    {
+      "start": 330.75,
+      "end": 330.91,
+      "text": "good"
+    },
+    {
+      "start": 330.92,
+      "end": 331.24,
+      "text": "vibes"
+    },
+    {
+      "start": 331.24,
+      "end": 331.4,
+      "text": "from"
+    },
+    {
+      "start": 331.39,
+      "end": 331.63,
+      "text": "them."
+    },
+    {
+      "start": 331.63,
+      "end": 331.79,
+      "text": "They're"
+    },
+    {
+      "start": 331.79,
+      "end": 332.19,
+      "text": "ready"
+    },
+    {
+      "start": 332.19,
+      "end": 332.27,
+      "text": "to"
+    },
+    {
+      "start": 332.27,
+      "end": 332.43,
+      "text": "hit"
+    },
+    {
+      "start": 332.44,
+      "end": 332.6,
+      "text": "the"
+    },
+    {
+      "start": 332.6,
+      "end": 332.76,
+      "text": "ground"
+    },
+    {
+      "start": 332.75,
+      "end": 333.23,
+      "text": "running."
+    },
+    {
+      "start": 333.24,
+      "end": 333.48,
+      "text": "They're"
+    },
+    {
+      "start": 333.48,
+      "end": 333.64,
+      "text": "kinda"
+    },
+    {
+      "start": 333.63,
+      "end": 334.03,
+      "text": "like"
+    },
+    {
+      "start": 335.16,
+      "end": 335.4,
+      "text": "start"
+    },
+    {
+      "start": 335.4,
+      "end": 335.72,
+      "text": "engaging"
+    },
+    {
+      "start": 335.72,
+      "end": 335.96,
+      "text": "on"
+    },
+    {
+      "start": 335.96,
+      "end": 336.04,
+      "text": "the"
+    },
+    {
+      "start": 336.04,
+      "end": 336.28,
+      "text": "mailing"
+    },
+    {
+      "start": 336.28,
+      "end": 336.76,
+      "text": "list,"
+    },
+    {
+      "start": 336.76,
+      "end": 337.16,
+      "text": "draft"
+    },
+    {
+      "start": 337.16,
+      "end": 337.32,
+      "text": "up"
+    },
+    {
+      "start": 337.32,
+      "end": 337.56,
+      "text": "some"
+    },
+    {
+      "start": 337.56,
+      "end": 338.04,
+      "text": "stuff."
+    },
+    {
+      "start": 338.28,
+      "end": 338.44,
+      "text": "We"
+    },
+    {
+      "start": 338.44,
+      "end": 338.68,
+      "text": "wanna"
+    },
+    {
+      "start": 338.68,
+      "end": 338.84,
+      "text": "have"
+    },
+    {
+      "start": 338.84,
+      "end": 338.92,
+      "text": "a"
+    },
+    {
+      "start": 338.92,
+      "end": 339,
+      "text": "lot"
+    },
+    {
+      "start": 339,
+      "end": 339.16,
+      "text": "of"
+    },
+    {
+      "start": 339.16,
+      "end": 339.4,
+      "text": "energy"
+    },
+    {
+      "start": 339.4,
+      "end": 339.64,
+      "text": "at"
+    },
+    {
+      "start": 339.64,
+      "end": 339.72,
+      "text": "the"
+    },
+    {
+      "start": 339.72,
+      "end": 339.88,
+      "text": "first"
+    },
+    {
+      "start": 339.88,
+      "end": 340.36,
+      "text": "meeting."
+    },
+    {
+      "start": 340.36,
+      "end": 340.76,
+      "text": "So,"
+    },
+    {
+      "start": 341.4,
+      "end": 341.56,
+      "text": "the"
+    },
+    {
+      "start": 341.56,
+      "end": 341.88,
+      "text": "vibes"
+    },
+    {
+      "start": 341.88,
+      "end": 342.04,
+      "text": "were"
+    },
+    {
+      "start": 342.04,
+      "end": 342.28,
+      "text": "good."
+    },
+    {
+      "start": 342.28,
+      "end": 342.52,
+      "text": "I'm"
+    },
+    {
+      "start": 342.52,
+      "end": 342.84,
+      "text": "excited"
+    },
+    {
+      "start": 342.84,
+      "end": 343.08,
+      "text": "about"
+    },
+    {
+      "start": 343.08,
+      "end": 343.56,
+      "text": "this."
+    },
+    {
+      "start": 344.12,
+      "end": 344.44,
+      "text": "This"
+    },
+    {
+      "start": 344.44,
+      "end": 344.6,
+      "text": "is"
+    },
+    {
+      "start": 344.6,
+      "end": 344.92,
+      "text": "our"
+    },
+    {
+      "start": 344.92,
+      "end": 345.32,
+      "text": "charter"
+    },
+    {
+      "start": 345.32,
+      "end": 345.64,
+      "text": "in"
+    },
+    {
+      "start": 345.64,
+      "end": 346.04,
+      "text": "very"
+    },
+    {
+      "start": 346.04,
+      "end": 346.36,
+      "text": "small"
+    },
+    {
+      "start": 346.36,
+      "end": 346.76,
+      "text": "font."
+    },
+    {
+      "start": 346.76,
+      "end": 346.92,
+      "text": "You"
+    },
+    {
+      "start": 346.92,
+      "end": 347.08,
+      "text": "can"
+    },
+    {
+      "start": 347.08,
+      "end": 347.48,
+      "text": "read"
+    },
+    {
+      "start": 347.48,
+      "end": 347.8,
+      "text": "the"
+    },
+    {
+      "start": 347.8,
+      "end": 348.2,
+      "text": "entire"
+    },
+    {
+      "start": 348.2,
+      "end": 348.52,
+      "text": "thing"
+    },
+    {
+      "start": 348.52,
+      "end": 348.84,
+      "text": "on"
+    },
+    {
+      "start": 348.84,
+      "end": 349,
+      "text": "the"
+    },
+    {
+      "start": 349,
+      "end": 349.56,
+      "text": "IETF"
+    },
+    {
+      "start": 349.56,
+      "end": 350.36,
+      "text": "data"
+    },
+    {
+      "start": 349.94,
+      "end": 350.66,
+      "text": "tracker."
+    },
+    {
+      "start": 351.21,
+      "end": 351.77,
+      "text": "This"
+    },
+    {
+      "start": 351.94,
+      "end": 352.42,
+      "text": "was"
+    },
+    {
+      "start": 352.5,
+      "end": 352.74,
+      "text": "on"
+    },
+    {
+      "start": 352.74,
+      "end": 352.9,
+      "text": "the"
+    },
+    {
+      "start": 352.89,
+      "end": 353.05,
+      "text": "note"
+    },
+    {
+      "start": 353.06,
+      "end": 353.22,
+      "text": "of"
+    },
+    {
+      "start": 353.21,
+      "end": 353.77,
+      "text": "bureaucracy"
+    },
+    {
+      "start": 353.77,
+      "end": 354.01,
+      "text": "for"
+    },
+    {
+      "start": 354.01,
+      "end": 354.33,
+      "text": "good."
+    },
+    {
+      "start": 354.33,
+      "end": 354.41,
+      "text": "This"
+    },
+    {
+      "start": 354.42,
+      "end": 354.66,
+      "text": "was"
+    },
+    {
+      "start": 354.65,
+      "end": 355.05,
+      "text": "four"
+    },
+    {
+      "start": 355.06,
+      "end": 355.3,
+      "text": "months"
+    },
+    {
+      "start": 355.29,
+      "end": 355.53,
+      "text": "of"
+    },
+    {
+      "start": 355.54,
+      "end": 355.78,
+      "text": "going"
+    },
+    {
+      "start": 355.77,
+      "end": 355.93,
+      "text": "back"
+    },
+    {
+      "start": 355.94,
+      "end": 356.1,
+      "text": "and"
+    },
+    {
+      "start": 356.1,
+      "end": 356.34,
+      "text": "forth"
+    },
+    {
+      "start": 356.33,
+      "end": 356.57,
+      "text": "on"
+    },
+    {
+      "start": 356.57,
+      "end": 356.65,
+      "text": "a"
+    },
+    {
+      "start": 356.65,
+      "end": 356.97,
+      "text": "mailing"
+    },
+    {
+      "start": 356.98,
+      "end": 357.22,
+      "text": "list"
+    },
+    {
+      "start": 357.21,
+      "end": 357.37,
+      "text": "to"
+    },
+    {
+      "start": 357.38,
+      "end": 357.54,
+      "text": "get"
+    },
+    {
+      "start": 357.54,
+      "end": 357.7,
+      "text": "that"
+    },
+    {
+      "start": 357.69,
+      "end": 358.01,
+      "text": "nailed"
+    },
+    {
+      "start": 358.01,
+      "end": 358.49,
+      "text": "down"
+    },
+    {
+      "start": 358.57,
+      "end": 358.81,
+      "text": "to"
+    },
+    {
+      "start": 358.81,
+      "end": 359.13,
+      "text": "decide"
+    },
+    {
+      "start": 359.13,
+      "end": 359.29,
+      "text": "what"
+    },
+    {
+      "start": 359.29,
+      "end": 359.45,
+      "text": "we"
+    },
+    {
+      "start": 359.45,
+      "end": 359.61,
+      "text": "were"
+    },
+    {
+      "start": 359.62,
+      "end": 359.7,
+      "text": "going"
+    },
+    {
+      "start": 359.69,
+      "end": 359.85,
+      "text": "to"
+    },
+    {
+      "start": 359.86,
+      "end": 360.02,
+      "text": "work"
+    },
+    {
+      "start": 360.01,
+      "end": 360.49,
+      "text": "on."
+    },
+    {
+      "start": 361.45,
+      "end": 361.77,
+      "text": "And"
+    },
+    {
+      "start": 361.77,
+      "end": 361.93,
+      "text": "to"
+    },
+    {
+      "start": 361.94,
+      "end": 362.26,
+      "text": "break"
+    },
+    {
+      "start": 362.25,
+      "end": 362.41,
+      "text": "down"
+    },
+    {
+      "start": 362.42,
+      "end": 362.66,
+      "text": "kind"
+    },
+    {
+      "start": 362.65,
+      "end": 362.73,
+      "text": "of"
+    },
+    {
+      "start": 362.74,
+      "end": 362.98,
+      "text": "what's"
+    },
+    {
+      "start": 362.98,
+      "end": 363.14,
+      "text": "in"
+    },
+    {
+      "start": 363.13,
+      "end": 363.29,
+      "text": "that,"
+    },
+    {
+      "start": 363.58,
+      "end": 363.9,
+      "text": "the"
+    },
+    {
+      "start": 363.98,
+      "end": 364.22,
+      "text": "what"
+    },
+    {
+      "start": 364.22,
+      "end": 364.3,
+      "text": "the"
+    },
+    {
+      "start": 364.3,
+      "end": 364.62,
+      "text": "charter"
+    },
+    {
+      "start": 364.62,
+      "end": 364.78,
+      "text": "for"
+    },
+    {
+      "start": 364.78,
+      "end": 364.94,
+      "text": "this"
+    },
+    {
+      "start": 364.94,
+      "end": 365.26,
+      "text": "working"
+    },
+    {
+      "start": 365.26,
+      "end": 365.5,
+      "text": "group"
+    },
+    {
+      "start": 365.5,
+      "end": 365.66,
+      "text": "is"
+    },
+    {
+      "start": 365.66,
+      "end": 365.98,
+      "text": "for"
+    },
+    {
+      "start": 365.98,
+      "end": 366.62,
+      "text": "is"
+    },
+    {
+      "start": 366.7,
+      "end": 366.94,
+      "text": "the"
+    },
+    {
+      "start": 366.94,
+      "end": 367.26,
+      "text": "structure"
+    },
+    {
+      "start": 367.26,
+      "end": 367.42,
+      "text": "of"
+    },
+    {
+      "start": 367.42,
+      "end": 367.5,
+      "text": "the"
+    },
+    {
+      "start": 367.5,
+      "end": 367.9,
+      "text": "repo"
+    },
+    {
+      "start": 367.9,
+      "end": 368.14,
+      "text": "and"
+    },
+    {
+      "start": 368.14,
+      "end": 368.3,
+      "text": "how"
+    },
+    {
+      "start": 368.3,
+      "end": 368.38,
+      "text": "we"
+    },
+    {
+      "start": 368.38,
+      "end": 368.7,
+      "text": "encode"
+    },
+    {
+      "start": 368.7,
+      "end": 369.02,
+      "text": "records"
+    },
+    {
+      "start": 369.02,
+      "end": 369.18,
+      "text": "in"
+    },
+    {
+      "start": 369.18,
+      "end": 369.5,
+      "text": "it."
+    },
+    {
+      "start": 369.5,
+      "end": 369.74,
+      "text": "The"
+    },
+    {
+      "start": 369.74,
+      "end": 370.06,
+      "text": "sync"
+    },
+    {
+      "start": 370.06,
+      "end": 370.46,
+      "text": "protocol"
+    },
+    {
+      "start": 370.46,
+      "end": 370.7,
+      "text": "for"
+    },
+    {
+      "start": 370.7,
+      "end": 371.18,
+      "text": "public"
+    },
+    {
+      "start": 371.18,
+      "end": 372.14,
+      "text": "repositories."
+    },
+    {
+      "start": 372.38,
+      "end": 372.54,
+      "text": "The"
+    },
+    {
+      "start": 372.54,
+      "end": 373.18,
+      "text": "AT"
+    },
+    {
+      "start": 373.18,
+      "end": 373.74,
+      "text": "URI"
+    },
+    {
+      "start": 373.74,
+      "end": 374.14,
+      "text": "scheme"
+    },
+    {
+      "start": 374.14,
+      "end": 374.38,
+      "text": "for"
+    },
+    {
+      "start": 374.38,
+      "end": 374.86,
+      "text": "addressing"
+    },
+    {
+      "start": 374.86,
+      "end": 375.18,
+      "text": "records"
+    },
+    {
+      "start": 375.18,
+      "end": 375.42,
+      "text": "in"
+    },
+    {
+      "start": 375.42,
+      "end": 375.58,
+      "text": "those"
+    },
+    {
+      "start": 375.58,
+      "end": 376.22,
+      "text": "repositories."
+    },
+    {
+      "start": 376.57,
+      "end": 376.89,
+      "text": "And"
+    },
+    {
+      "start": 376.9,
+      "end": 377.06,
+      "text": "then"
+    },
+    {
+      "start": 377.06,
+      "end": 377.62,
+      "text": "interface"
+    },
+    {
+      "start": 377.62,
+      "end": 378.18,
+      "text": "requirements"
+    },
+    {
+      "start": 378.18,
+      "end": 378.5,
+      "text": "and"
+    },
+    {
+      "start": 378.5,
+      "end": 378.9,
+      "text": "selection"
+    },
+    {
+      "start": 378.9,
+      "end": 379.38,
+      "text": "criteria"
+    },
+    {
+      "start": 379.38,
+      "end": 379.62,
+      "text": "for"
+    },
+    {
+      "start": 379.62,
+      "end": 379.86,
+      "text": "an"
+    },
+    {
+      "start": 379.86,
+      "end": 380.34,
+      "text": "identifier"
+    },
+    {
+      "start": 380.34,
+      "end": 380.9,
+      "text": "resolution"
+    },
+    {
+      "start": 380.9,
+      "end": 381.54,
+      "text": "system."
+    },
+    {
+      "start": 381.86,
+      "end": 382.18,
+      "text": "This"
+    },
+    {
+      "start": 382.18,
+      "end": 382.34,
+      "text": "was"
+    },
+    {
+      "start": 382.34,
+      "end": 382.58,
+      "text": "kind"
+    },
+    {
+      "start": 382.57,
+      "end": 382.73,
+      "text": "of"
+    },
+    {
+      "start": 382.74,
+      "end": 382.98,
+      "text": "the"
+    },
+    {
+      "start": 382.98,
+      "end": 383.46,
+      "text": "hardest"
+    },
+    {
+      "start": 383.46,
+      "end": 383.7,
+      "text": "part"
+    },
+    {
+      "start": 383.69,
+      "end": 383.93,
+      "text": "of"
+    },
+    {
+      "start": 383.94,
+      "end": 384.26,
+      "text": "nailing"
+    },
+    {
+      "start": 384.25,
+      "end": 384.49,
+      "text": "down"
+    },
+    {
+      "start": 384.5,
+      "end": 384.66,
+      "text": "the"
+    },
+    {
+      "start": 384.65,
+      "end": 385.05,
+      "text": "charter,"
+    },
+    {
+      "start": 385.06,
+      "end": 385.14,
+      "text": "which"
+    },
+    {
+      "start": 385.13,
+      "end": 385.29,
+      "text": "is"
+    },
+    {
+      "start": 385.3,
+      "end": 385.46,
+      "text": "that"
+    },
+    {
+      "start": 385.46,
+      "end": 385.62,
+      "text": "we"
+    },
+    {
+      "start": 385.62,
+      "end": 385.78,
+      "text": "did"
+    },
+    {
+      "start": 385.78,
+      "end": 386.02,
+      "text": "not"
+    },
+    {
+      "start": 386.01,
+      "end": 386.25,
+      "text": "want"
+    },
+    {
+      "start": 386.25,
+      "end": 386.57,
+      "text": "to"
+    },
+    {
+      "start": 386.57,
+      "end": 386.97,
+      "text": "pull"
+    },
+    {
+      "start": 386.98,
+      "end": 387.38,
+      "text": "DIDs"
+    },
+    {
+      "start": 387.38,
+      "end": 387.62,
+      "text": "into"
+    },
+    {
+      "start": 387.62,
+      "end": 387.78,
+      "text": "the"
+    },
+    {
+      "start": 387.78,
+      "end": 388.58,
+      "text": "IETF."
+    },
+    {
+      "start": 388.57,
+      "end": 388.73,
+      "text": "We"
+    },
+    {
+      "start": 388.74,
+      "end": 388.9,
+      "text": "did"
+    },
+    {
+      "start": 388.9,
+      "end": 389.14,
+      "text": "not"
+    },
+    {
+      "start": 389.13,
+      "end": 389.37,
+      "text": "want"
+    },
+    {
+      "start": 389.38,
+      "end": 390.5,
+      "text": "to"
+    },
+    {
+      "start": 389.64,
+      "end": 390.04,
+      "text": "wade"
+    },
+    {
+      "start": 390.04,
+      "end": 390.28,
+      "text": "into"
+    },
+    {
+      "start": 390.28,
+      "end": 390.44,
+      "text": "the"
+    },
+    {
+      "start": 390.44,
+      "end": 391.08,
+      "text": "quagmire"
+    },
+    {
+      "start": 391.08,
+      "end": 391.48,
+      "text": "of"
+    },
+    {
+      "start": 391.48,
+      "end": 392.12,
+      "text": "specifying"
+    },
+    {
+      "start": 392.12,
+      "end": 392.92,
+      "text": "identity."
+    },
+    {
+      "start": 393.88,
+      "end": 394.28,
+      "text": "So,"
+    },
+    {
+      "start": 394.28,
+      "end": 394.44,
+      "text": "we"
+    },
+    {
+      "start": 394.44,
+      "end": 394.68,
+      "text": "kind"
+    },
+    {
+      "start": 394.68,
+      "end": 395.08,
+      "text": "of"
+    },
+    {
+      "start": 395.16,
+      "end": 395.64,
+      "text": "There's"
+    },
+    {
+      "start": 395.64,
+      "end": 395.8,
+      "text": "a"
+    },
+    {
+      "start": 395.8,
+      "end": 396.36,
+      "text": "identity"
+    },
+    {
+      "start": 396.36,
+      "end": 396.68,
+      "text": "shaped"
+    },
+    {
+      "start": 396.68,
+      "end": 397,
+      "text": "hole"
+    },
+    {
+      "start": 397,
+      "end": 397.16,
+      "text": "in"
+    },
+    {
+      "start": 397.16,
+      "end": 397.32,
+      "text": "the"
+    },
+    {
+      "start": 397.32,
+      "end": 397.64,
+      "text": "spec,"
+    },
+    {
+      "start": 397.64,
+      "end": 397.8,
+      "text": "and"
+    },
+    {
+      "start": 397.8,
+      "end": 397.96,
+      "text": "we're"
+    },
+    {
+      "start": 397.96,
+      "end": 398.36,
+      "text": "specifying"
+    },
+    {
+      "start": 398.36,
+      "end": 398.6,
+      "text": "the"
+    },
+    {
+      "start": 398.6,
+      "end": 398.84,
+      "text": "shape"
+    },
+    {
+      "start": 398.84,
+      "end": 399,
+      "text": "of"
+    },
+    {
+      "start": 399,
+      "end": 399.16,
+      "text": "that"
+    },
+    {
+      "start": 399.16,
+      "end": 399.72,
+      "text": "hole."
+    },
+    {
+      "start": 401.08,
+      "end": 401.32,
+      "text": "We"
+    },
+    {
+      "start": 401.32,
+      "end": 401.48,
+      "text": "are"
+    },
+    {
+      "start": 401.48,
+      "end": 401.72,
+      "text": "not"
+    },
+    {
+      "start": 401.72,
+      "end": 401.96,
+      "text": "going"
+    },
+    {
+      "start": 401.96,
+      "end": 402.12,
+      "text": "to"
+    },
+    {
+      "start": 402.12,
+      "end": 402.28,
+      "text": "be"
+    },
+    {
+      "start": 402.6,
+      "end": 402.84,
+      "text": "This"
+    },
+    {
+      "start": 402.84,
+      "end": 403.08,
+      "text": "working"
+    },
+    {
+      "start": 403.08,
+      "end": 403.32,
+      "text": "group"
+    },
+    {
+      "start": 403.32,
+      "end": 403.48,
+      "text": "is"
+    },
+    {
+      "start": 403.48,
+      "end": 403.64,
+      "text": "not"
+    },
+    {
+      "start": 403.64,
+      "end": 403.8,
+      "text": "going"
+    },
+    {
+      "start": 403.8,
+      "end": 403.88,
+      "text": "to"
+    },
+    {
+      "start": 403.88,
+      "end": 403.96,
+      "text": "be"
+    },
+    {
+      "start": 403.96,
+      "end": 404.2,
+      "text": "doing"
+    },
+    {
+      "start": 404.2,
+      "end": 404.92,
+      "text": "lexicon,"
+    },
+    {
+      "start": 405.27,
+      "end": 405.67,
+      "text": "any"
+    },
+    {
+      "start": 405.68,
+      "end": 406.16,
+      "text": "micro"
+    },
+    {
+      "start": 406.15,
+      "end": 406.95,
+      "text": "blogging,"
+    },
+    {
+      "start": 407.19,
+      "end": 407.35,
+      "text": "or"
+    },
+    {
+      "start": 407.36,
+      "end": 407.84,
+      "text": "social"
+    },
+    {
+      "start": 407.84,
+      "end": 408.32,
+      "text": "semantics"
+    },
+    {
+      "start": 408.31,
+      "end": 408.47,
+      "text": "at"
+    },
+    {
+      "start": 408.48,
+      "end": 408.96,
+      "text": "all."
+    },
+    {
+      "start": 409.12,
+      "end": 409.68,
+      "text": "Identity,"
+    },
+    {
+      "start": 409.68,
+      "end": 409.92,
+      "text": "as"
+    },
+    {
+      "start": 409.92,
+      "end": 410,
+      "text": "I"
+    },
+    {
+      "start": 410,
+      "end": 410.56,
+      "text": "mentioned,"
+    },
+    {
+      "start": 410.56,
+      "end": 411.28,
+      "text": "labeling,"
+    },
+    {
+      "start": 411.27,
+      "end": 411.43,
+      "text": "and"
+    },
+    {
+      "start": 411.44,
+      "end": 411.52,
+      "text": "the"
+    },
+    {
+      "start": 411.51,
+      "end": 411.83,
+      "text": "permission"
+    },
+    {
+      "start": 411.84,
+      "end": 412.16,
+      "text": "data"
+    },
+    {
+      "start": 412.15,
+      "end": 412.39,
+      "text": "work"
+    },
+    {
+      "start": 412.4,
+      "end": 412.48,
+      "text": "that"
+    },
+    {
+      "start": 412.48,
+      "end": 412.72,
+      "text": "we're"
+    },
+    {
+      "start": 412.71,
+      "end": 412.87,
+      "text": "working"
+    },
+    {
+      "start": 412.88,
+      "end": 412.96,
+      "text": "on"
+    },
+    {
+      "start": 412.96,
+      "end": 413.2,
+      "text": "right"
+    },
+    {
+      "start": 413.19,
+      "end": 413.27,
+      "text": "now"
+    },
+    {
+      "start": 413.27,
+      "end": 413.51,
+      "text": "is"
+    },
+    {
+      "start": 413.51,
+      "end": 413.75,
+      "text": "outside"
+    },
+    {
+      "start": 413.75,
+      "end": 413.91,
+      "text": "of"
+    },
+    {
+      "start": 413.92,
+      "end": 414,
+      "text": "the"
+    },
+    {
+      "start": 414,
+      "end": 414.24,
+      "text": "working"
+    },
+    {
+      "start": 414.24,
+      "end": 414.48,
+      "text": "group"
+    },
+    {
+      "start": 414.48,
+      "end": 414.64,
+      "text": "as"
+    },
+    {
+      "start": 414.63,
+      "end": 415.11,
+      "text": "well."
+    },
+    {
+      "start": 415.84,
+      "end": 416.4,
+      "text": "Though,"
+    },
+    {
+      "start": 417.19,
+      "end": 417.43,
+      "text": "parts"
+    },
+    {
+      "start": 417.44,
+      "end": 417.6,
+      "text": "of"
+    },
+    {
+      "start": 417.6,
+      "end": 417.76,
+      "text": "this"
+    },
+    {
+      "start": 417.75,
+      "end": 418.07,
+      "text": "may,"
+    },
+    {
+      "start": 418.34,
+      "end": 418.58,
+      "text": "we"
+    },
+    {
+      "start": 418.58,
+      "end": 418.74,
+      "text": "may"
+    },
+    {
+      "start": 418.74,
+      "end": 418.9,
+      "text": "have"
+    },
+    {
+      "start": 418.9,
+      "end": 419.3,
+      "text": "recharted"
+    },
+    {
+      "start": 419.3,
+      "end": 419.46,
+      "text": "the"
+    },
+    {
+      "start": 419.46,
+      "end": 419.62,
+      "text": "work."
+    },
+    {
+      "start": 419.62,
+      "end": 419.78,
+      "text": "If"
+    },
+    {
+      "start": 419.78,
+      "end": 420.02,
+      "text": "everything"
+    },
+    {
+      "start": 420.02,
+      "end": 420.26,
+      "text": "goes"
+    },
+    {
+      "start": 420.26,
+      "end": 420.42,
+      "text": "well"
+    },
+    {
+      "start": 420.42,
+      "end": 420.66,
+      "text": "for"
+    },
+    {
+      "start": 420.66,
+      "end": 420.82,
+      "text": "both"
+    },
+    {
+      "start": 420.82,
+      "end": 421.22,
+      "text": "parties,"
+    },
+    {
+      "start": 421.22,
+      "end": 421.3,
+      "text": "we"
+    },
+    {
+      "start": 421.3,
+      "end": 421.38,
+      "text": "may"
+    },
+    {
+      "start": 421.38,
+      "end": 421.54,
+      "text": "be"
+    },
+    {
+      "start": 421.54,
+      "end": 422.02,
+      "text": "recharted"
+    },
+    {
+      "start": 422.02,
+      "end": 422.18,
+      "text": "the"
+    },
+    {
+      "start": 422.18,
+      "end": 422.42,
+      "text": "working"
+    },
+    {
+      "start": 422.42,
+      "end": 422.74,
+      "text": "group"
+    },
+    {
+      "start": 422.74,
+      "end": 422.98,
+      "text": "in"
+    },
+    {
+      "start": 422.98,
+      "end": 423.14,
+      "text": "the"
+    },
+    {
+      "start": 423.14,
+      "end": 423.38,
+      "text": "future"
+    },
+    {
+      "start": 423.38,
+      "end": 423.62,
+      "text": "and"
+    },
+    {
+      "start": 423.62,
+      "end": 423.86,
+      "text": "address"
+    },
+    {
+      "start": 423.86,
+      "end": 424.1,
+      "text": "some"
+    },
+    {
+      "start": 424.1,
+      "end": 424.18,
+      "text": "of"
+    },
+    {
+      "start": 424.18,
+      "end": 424.66,
+      "text": "these."
+    },
+    {
+      "start": 425.46,
+      "end": 425.86,
+      "text": "So,"
+    },
+    {
+      "start": 425.86,
+      "end": 426.02,
+      "text": "just"
+    },
+    {
+      "start": 426.02,
+      "end": 426.1,
+      "text": "to"
+    },
+    {
+      "start": 426.1,
+      "end": 426.26,
+      "text": "call"
+    },
+    {
+      "start": 426.26,
+      "end": 426.42,
+      "text": "it"
+    },
+    {
+      "start": 426.42,
+      "end": 426.66,
+      "text": "out,"
+    },
+    {
+      "start": 426.66,
+      "end": 426.82,
+      "text": "this"
+    },
+    {
+      "start": 426.82,
+      "end": 426.98,
+      "text": "is"
+    },
+    {
+      "start": 426.98,
+      "end": 427.22,
+      "text": "your"
+    },
+    {
+      "start": 427.22,
+      "end": 427.54,
+      "text": "chance"
+    },
+    {
+      "start": 427.54,
+      "end": 427.7,
+      "text": "to"
+    },
+    {
+      "start": 427.7,
+      "end": 428.02,
+      "text": "contribute"
+    },
+    {
+      "start": 428.02,
+      "end": 428.34,
+      "text": "to"
+    },
+    {
+      "start": 428.34,
+      "end": 428.42,
+      "text": "the"
+    },
+    {
+      "start": 428.42,
+      "end": 428.9,
+      "text": "technical"
+    },
+    {
+      "start": 428.9,
+      "end": 429.38,
+      "text": "direction"
+    },
+    {
+      "start": 429.38,
+      "end": 429.54,
+      "text": "of"
+    },
+    {
+      "start": 429.54,
+      "end": 429.7,
+      "text": "the"
+    },
+    {
+      "start": 429.7,
+      "end": 430.26,
+      "text": "protocol."
+    },
+    {
+      "start": 430.26,
+      "end": 430.5,
+      "text": "As"
+    },
+    {
+      "start": 430.5,
+      "end": 430.58,
+      "text": "I"
+    },
+    {
+      "start": 430.58,
+      "end": 430.82,
+      "text": "said,"
+    },
+    {
+      "start": 430.82,
+      "end": 430.98,
+      "text": "this"
+    },
+    {
+      "start": 430.98,
+      "end": 431.06,
+      "text": "is"
+    },
+    {
+      "start": 431.06,
+      "end": 431.38,
+      "text": "open"
+    },
+    {
+      "start": 431.38,
+      "end": 431.78,
+      "text": "membership."
+    },
+    {
+      "start": 431.89,
+      "end": 432.29,
+      "text": "Anybody"
+    },
+    {
+      "start": 432.29,
+      "end": 432.53,
+      "text": "can"
+    },
+    {
+      "start": 432.54,
+      "end": 432.78,
+      "text": "hop"
+    },
+    {
+      "start": 432.77,
+      "end": 432.93,
+      "text": "in"
+    },
+    {
+      "start": 432.94,
+      "end": 433.26,
+      "text": "here."
+    },
+    {
+      "start": 433.25,
+      "end": 433.41,
+      "text": "If"
+    },
+    {
+      "start": 433.41,
+      "end": 433.49,
+      "text": "you"
+    },
+    {
+      "start": 433.5,
+      "end": 433.66,
+      "text": "think"
+    },
+    {
+      "start": 433.65,
+      "end": 433.81,
+      "text": "that"
+    },
+    {
+      "start": 433.81,
+      "end": 433.89,
+      "text": "we"
+    },
+    {
+      "start": 433.89,
+      "end": 434.21,
+      "text": "screwed"
+    },
+    {
+      "start": 434.21,
+      "end": 434.29,
+      "text": "it"
+    },
+    {
+      "start": 434.29,
+      "end": 434.45,
+      "text": "up"
+    },
+    {
+      "start": 434.45,
+      "end": 434.61,
+      "text": "and"
+    },
+    {
+      "start": 434.62,
+      "end": 434.7,
+      "text": "the"
+    },
+    {
+      "start": 434.69,
+      "end": 435.01,
+      "text": "protocol"
+    },
+    {
+      "start": 435.01,
+      "end": 435.25,
+      "text": "is"
+    },
+    {
+      "start": 435.25,
+      "end": 435.57,
+      "text": "stupid"
+    },
+    {
+      "start": 435.57,
+      "end": 435.73,
+      "text": "or"
+    },
+    {
+      "start": 435.74,
+      "end": 435.98,
+      "text": "ugly"
+    },
+    {
+      "start": 435.97,
+      "end": 436.13,
+      "text": "or"
+    },
+    {
+      "start": 436.13,
+      "end": 436.53,
+      "text": "whatever,"
+    },
+    {
+      "start": 436.54,
+      "end": 436.7,
+      "text": "this"
+    },
+    {
+      "start": 436.69,
+      "end": 436.77,
+      "text": "is"
+    },
+    {
+      "start": 436.77,
+      "end": 436.93,
+      "text": "your"
+    },
+    {
+      "start": 436.94,
+      "end": 437.18,
+      "text": "chance"
+    },
+    {
+      "start": 437.18,
+      "end": 437.34,
+      "text": "to"
+    },
+    {
+      "start": 437.33,
+      "end": 437.49,
+      "text": "say"
+    },
+    {
+      "start": 437.5,
+      "end": 437.74,
+      "text": "it"
+    },
+    {
+      "start": 437.74,
+      "end": 438.46,
+      "text": "and"
+    },
+    {
+      "start": 438.85,
+      "end": 439.25,
+      "text": "actually"
+    },
+    {
+      "start": 439.25,
+      "end": 439.57,
+      "text": "have"
+    },
+    {
+      "start": 439.57,
+      "end": 439.73,
+      "text": "an"
+    },
+    {
+      "start": 439.74,
+      "end": 439.98,
+      "text": "impact"
+    },
+    {
+      "start": 439.97,
+      "end": 440.13,
+      "text": "on"
+    },
+    {
+      "start": 440.13,
+      "end": 440.29,
+      "text": "the"
+    },
+    {
+      "start": 440.29,
+      "end": 440.77,
+      "text": "protocol."
+    },
+    {
+      "start": 440.77,
+      "end": 440.93,
+      "text": "You"
+    },
+    {
+      "start": 441.1,
+      "end": 441.26,
+      "text": "In"
+    },
+    {
+      "start": 441.25,
+      "end": 441.49,
+      "text": "in"
+    },
+    {
+      "start": 441.5,
+      "end": 441.74,
+      "text": "some"
+    },
+    {
+      "start": 441.74,
+      "end": 442.06,
+      "text": "very"
+    },
+    {
+      "start": 442.06,
+      "end": 442.38,
+      "text": "real"
+    },
+    {
+      "start": 442.38,
+      "end": 442.7,
+      "text": "sense,"
+    },
+    {
+      "start": 442.69,
+      "end": 442.77,
+      "text": "you"
+    },
+    {
+      "start": 442.77,
+      "end": 442.93,
+      "text": "are"
+    },
+    {
+      "start": 442.94,
+      "end": 443.1,
+      "text": "on"
+    },
+    {
+      "start": 443.1,
+      "end": 443.26,
+      "text": "an"
+    },
+    {
+      "start": 443.25,
+      "end": 443.49,
+      "text": "equal"
+    },
+    {
+      "start": 443.5,
+      "end": 443.82,
+      "text": "playing"
+    },
+    {
+      "start": 443.81,
+      "end": 444.21,
+      "text": "field"
+    },
+    {
+      "start": 444.21,
+      "end": 444.61,
+      "text": "as"
+    },
+    {
+      "start": 444.62,
+      "end": 445.02,
+      "text": "Brian"
+    },
+    {
+      "start": 445.01,
+      "end": 445.25,
+      "text": "or"
+    },
+    {
+      "start": 445.25,
+      "end": 446.61,
+      "text": "I"
+    },
+    {
+      "start": 446.16,
+      "end": 446.4,
+      "text": "on"
+    },
+    {
+      "start": 446.4,
+      "end": 446.56,
+      "text": "that"
+    },
+    {
+      "start": 446.56,
+      "end": 446.88,
+      "text": "mailing"
+    },
+    {
+      "start": 446.88,
+      "end": 447.12,
+      "text": "list"
+    },
+    {
+      "start": 447.12,
+      "end": 447.28,
+      "text": "and"
+    },
+    {
+      "start": 447.28,
+      "end": 447.36,
+      "text": "in"
+    },
+    {
+      "start": 447.36,
+      "end": 447.52,
+      "text": "that"
+    },
+    {
+      "start": 447.52,
+      "end": 448.08,
+      "text": "room."
+    },
+    {
+      "start": 450,
+      "end": 450.48,
+      "text": "So,"
+    },
+    {
+      "start": 450.48,
+      "end": 450.64,
+      "text": "just"
+    },
+    {
+      "start": 450.64,
+      "end": 450.8,
+      "text": "to"
+    },
+    {
+      "start": 450.8,
+      "end": 450.88,
+      "text": "give"
+    },
+    {
+      "start": 450.88,
+      "end": 451.04,
+      "text": "you"
+    },
+    {
+      "start": 451.04,
+      "end": 451.12,
+      "text": "a"
+    },
+    {
+      "start": 451.12,
+      "end": 451.28,
+      "text": "sense"
+    },
+    {
+      "start": 451.28,
+      "end": 451.44,
+      "text": "for"
+    },
+    {
+      "start": 451.44,
+      "end": 452.24,
+      "text": "participation,"
+    },
+    {
+      "start": 452.24,
+      "end": 452.4,
+      "text": "as"
+    },
+    {
+      "start": 452.4,
+      "end": 452.48,
+      "text": "I"
+    },
+    {
+      "start": 452.48,
+      "end": 452.72,
+      "text": "said,"
+    },
+    {
+      "start": 452.72,
+      "end": 452.96,
+      "text": "anyone"
+    },
+    {
+      "start": 452.96,
+      "end": 453.12,
+      "text": "can"
+    },
+    {
+      "start": 453.12,
+      "end": 453.84,
+      "text": "participate."
+    },
+    {
+      "start": 453.84,
+      "end": 454.16,
+      "text": "There's"
+    },
+    {
+      "start": 454.16,
+      "end": 454.4,
+      "text": "three"
+    },
+    {
+      "start": 454.4,
+      "end": 454.56,
+      "text": "in"
+    },
+    {
+      "start": 454.56,
+      "end": 454.8,
+      "text": "person"
+    },
+    {
+      "start": 454.8,
+      "end": 455.2,
+      "text": "meetings"
+    },
+    {
+      "start": 455.2,
+      "end": 455.52,
+      "text": "a"
+    },
+    {
+      "start": 455.52,
+      "end": 455.92,
+      "text": "year."
+    },
+    {
+      "start": 455.92,
+      "end": 456.08,
+      "text": "One"
+    },
+    {
+      "start": 456.08,
+      "end": 456.24,
+      "text": "in"
+    },
+    {
+      "start": 456.24,
+      "end": 456.48,
+      "text": "North"
+    },
+    {
+      "start": 456.48,
+      "end": 456.96,
+      "text": "America,"
+    },
+    {
+      "start": 456.96,
+      "end": 457.04,
+      "text": "one"
+    },
+    {
+      "start": 457.04,
+      "end": 457.2,
+      "text": "in"
+    },
+    {
+      "start": 457.2,
+      "end": 457.52,
+      "text": "Europe,"
+    },
+    {
+      "start": 457.52,
+      "end": 457.6,
+      "text": "and"
+    },
+    {
+      "start": 457.6,
+      "end": 457.76,
+      "text": "one"
+    },
+    {
+      "start": 457.76,
+      "end": 457.92,
+      "text": "in"
+    },
+    {
+      "start": 457.92,
+      "end": 458.4,
+      "text": "Asia,"
+    },
+    {
+      "start": 458.4,
+      "end": 458.64,
+      "text": "generally."
+    },
+    {
+      "start": 459.08,
+      "end": 459.32,
+      "text": "They"
+    },
+    {
+      "start": 459.32,
+      "end": 459.48,
+      "text": "have"
+    },
+    {
+      "start": 459.49,
+      "end": 459.57,
+      "text": "a"
+    },
+    {
+      "start": 459.56,
+      "end": 459.72,
+      "text": "very"
+    },
+    {
+      "start": 459.72,
+      "end": 459.88,
+      "text": "good"
+    },
+    {
+      "start": 459.88,
+      "end": 460.2,
+      "text": "remote"
+    },
+    {
+      "start": 460.2,
+      "end": 460.52,
+      "text": "first"
+    },
+    {
+      "start": 460.52,
+      "end": 461.32,
+      "text": "experience."
+    },
+    {
+      "start": 461.49,
+      "end": 462.13,
+      "text": "And"
+    },
+    {
+      "start": 462.6,
+      "end": 463.08,
+      "text": "usually,"
+    },
+    {
+      "start": 463.08,
+      "end": 463.16,
+      "text": "if"
+    },
+    {
+      "start": 463.16,
+      "end": 463.4,
+      "text": "you're"
+    },
+    {
+      "start": 463.4,
+      "end": 463.8,
+      "text": "attending"
+    },
+    {
+      "start": 463.81,
+      "end": 464.13,
+      "text": "remote"
+    },
+    {
+      "start": 464.13,
+      "end": 464.37,
+      "text": "and"
+    },
+    {
+      "start": 464.37,
+      "end": 464.61,
+      "text": "only"
+    },
+    {
+      "start": 464.6,
+      "end": 464.76,
+      "text": "for"
+    },
+    {
+      "start": 464.76,
+      "end": 465,
+      "text": "one"
+    },
+    {
+      "start": 465,
+      "end": 465.24,
+      "text": "day,"
+    },
+    {
+      "start": 465.25,
+      "end": 465.49,
+      "text": "they'll"
+    },
+    {
+      "start": 465.49,
+      "end": 465.57,
+      "text": "give"
+    },
+    {
+      "start": 465.56,
+      "end": 465.64,
+      "text": "you"
+    },
+    {
+      "start": 465.64,
+      "end": 465.8,
+      "text": "a"
+    },
+    {
+      "start": 465.81,
+      "end": 465.97,
+      "text": "free"
+    },
+    {
+      "start": 465.96,
+      "end": 466.52,
+      "text": "ticket."
+    },
+    {
+      "start": 467.32,
+      "end": 467.48,
+      "text": "So"
+    },
+    {
+      "start": 467.49,
+      "end": 467.81,
+      "text": "that"
+    },
+    {
+      "start": 467.81,
+      "end": 467.97,
+      "text": "is"
+    },
+    {
+      "start": 467.96,
+      "end": 468.12,
+      "text": "that"
+    },
+    {
+      "start": 468.13,
+      "end": 468.37,
+      "text": "is"
+    },
+    {
+      "start": 468.37,
+      "end": 468.93,
+      "text": "great."
+    },
+    {
+      "start": 469.49,
+      "end": 469.81,
+      "text": "The"
+    },
+    {
+      "start": 469.81,
+      "end": 470.13,
+      "text": "first"
+    },
+    {
+      "start": 470.13,
+      "end": 470.53,
+      "text": "working"
+    },
+    {
+      "start": 470.52,
+      "end": 470.76,
+      "text": "group"
+    },
+    {
+      "start": 470.76,
+      "end": 471.08,
+      "text": "meeting"
+    },
+    {
+      "start": 471.08,
+      "end": 471.32,
+      "text": "will"
+    },
+    {
+      "start": 471.32,
+      "end": 471.8,
+      "text": "be"
+    },
+    {
+      "start": 472.85,
+      "end": 473.17,
+      "text": "will"
+    },
+    {
+      "start": 473.17,
+      "end": 473.57,
+      "text": "probably"
+    },
+    {
+      "start": 473.57,
+      "end": 473.81,
+      "text": "be"
+    },
+    {
+      "start": 473.81,
+      "end": 473.89,
+      "text": "at"
+    },
+    {
+      "start": 473.89,
+      "end": 474.53,
+      "text": "IETF"
+    },
+    {
+      "start": 474.53,
+      "end": 474.69,
+      "text": "one"
+    },
+    {
+      "start": 474.69,
+      "end": 474.93,
+      "text": "twenty"
+    },
+    {
+      "start": 474.93,
+      "end": 475.09,
+      "text": "six"
+    },
+    {
+      "start": 475.09,
+      "end": 475.33,
+      "text": "in"
+    },
+    {
+      "start": 475.33,
+      "end": 475.89,
+      "text": "Vienna,"
+    },
+    {
+      "start": 475.89,
+      "end": 476.05,
+      "text": "is"
+    },
+    {
+      "start": 476.05,
+      "end": 476.29,
+      "text": "this"
+    },
+    {
+      "start": 476.29,
+      "end": 476.77,
+      "text": "summer,"
+    },
+    {
+      "start": 476.77,
+      "end": 477.33,
+      "text": "July."
+    },
+    {
+      "start": 477.41,
+      "end": 477.65,
+      "text": "We"
+    },
+    {
+      "start": 477.65,
+      "end": 477.89,
+      "text": "may"
+    },
+    {
+      "start": 477.89,
+      "end": 478.05,
+      "text": "do"
+    },
+    {
+      "start": 478.05,
+      "end": 478.21,
+      "text": "a"
+    },
+    {
+      "start": 478.21,
+      "end": 478.53,
+      "text": "remote"
+    },
+    {
+      "start": 478.53,
+      "end": 479.01,
+      "text": "interim"
+    },
+    {
+      "start": 479.01,
+      "end": 479.41,
+      "text": "meeting"
+    },
+    {
+      "start": 479.41,
+      "end": 480.29,
+      "text": "beforehand,"
+    },
+    {
+      "start": 480.53,
+      "end": 480.93,
+      "text": "and"
+    },
+    {
+      "start": 480.93,
+      "end": 481.17,
+      "text": "I"
+    },
+    {
+      "start": 481.17,
+      "end": 481.33,
+      "text": "will"
+    },
+    {
+      "start": 481.33,
+      "end": 481.57,
+      "text": "keep"
+    },
+    {
+      "start": 481.57,
+      "end": 481.81,
+      "text": "people"
+    },
+    {
+      "start": 481.81,
+      "end": 482.13,
+      "text": "updated"
+    },
+    {
+      "start": 482.13,
+      "end": 482.45,
+      "text": "on"
+    },
+    {
+      "start": 482.45,
+      "end": 482.93,
+      "text": "that."
+    },
+    {
+      "start": 483.09,
+      "end": 483.33,
+      "text": "But"
+    },
+    {
+      "start": 483.33,
+      "end": 483.97,
+      "text": "regardless,"
+    },
+    {
+      "start": 483.97,
+      "end": 484.13,
+      "text": "follow"
+    },
+    {
+      "start": 484.13,
+      "end": 484.37,
+      "text": "along"
+    },
+    {
+      "start": 484.37,
+      "end": 484.61,
+      "text": "on"
+    },
+    {
+      "start": 484.61,
+      "end": 484.69,
+      "text": "the"
+    },
+    {
+      "start": 484.69,
+      "end": 484.93,
+      "text": "mailing"
+    },
+    {
+      "start": 484.93,
+      "end": 485.17,
+      "text": "list."
+    },
+    {
+      "start": 485.17,
+      "end": 485.33,
+      "text": "It's"
+    },
+    {
+      "start": 485.33,
+      "end": 486.93,
+      "text": "atp@ietf.org."
+    },
+    {
+      "start": 486.93,
+      "end": 487.09,
+      "text": "Brian"
+    },
+    {
+      "start": 487.09,
+      "end": 487.25,
+      "text": "and"
+    },
+    {
+      "start": 487.25,
+      "end": 487.41,
+      "text": "I"
+    },
+    {
+      "start": 487.41,
+      "end": 487.49,
+      "text": "are"
+    },
+    {
+      "start": 487.49,
+      "end": 487.65,
+      "text": "gonna"
+    },
+    {
+      "start": 487.65,
+      "end": 488.53,
+      "text": "be"
+    },
+    {
+      "start": 487.85,
+      "end": 488.01,
+      "text": "trying"
+    },
+    {
+      "start": 488,
+      "end": 488.08,
+      "text": "to"
+    },
+    {
+      "start": 488.08,
+      "end": 488.24,
+      "text": "send"
+    },
+    {
+      "start": 488.25,
+      "end": 488.41,
+      "text": "out"
+    },
+    {
+      "start": 488.4,
+      "end": 488.56,
+      "text": "some"
+    },
+    {
+      "start": 488.56,
+      "end": 488.72,
+      "text": "stuff"
+    },
+    {
+      "start": 488.73,
+      "end": 488.89,
+      "text": "on"
+    },
+    {
+      "start": 488.88,
+      "end": 489.36,
+      "text": "there"
+    },
+    {
+      "start": 489.52,
+      "end": 490,
+      "text": "somewhat"
+    },
+    {
+      "start": 490,
+      "end": 490.32,
+      "text": "soon."
+    },
+    {
+      "start": 490.32,
+      "end": 490.4,
+      "text": "So"
+    },
+    {
+      "start": 490.4,
+      "end": 490.64,
+      "text": "hop"
+    },
+    {
+      "start": 490.64,
+      "end": 490.8,
+      "text": "in"
+    },
+    {
+      "start": 490.81,
+      "end": 490.97,
+      "text": "and"
+    },
+    {
+      "start": 490.96,
+      "end": 491.28,
+      "text": "let"
+    },
+    {
+      "start": 491.29,
+      "end": 491.37,
+      "text": "us"
+    },
+    {
+      "start": 491.37,
+      "end": 491.53,
+      "text": "know"
+    },
+    {
+      "start": 491.52,
+      "end": 491.76,
+      "text": "your"
+    },
+    {
+      "start": 491.76,
+      "end": 492.24,
+      "text": "thoughts."
+    },
+    {
+      "start": 493.13,
+      "end": 493.45,
+      "text": "Okay."
+    },
+    {
+      "start": 493.44,
+      "end": 493.6,
+      "text": "On"
+    },
+    {
+      "start": 493.61,
+      "end": 493.77,
+      "text": "to"
+    },
+    {
+      "start": 493.76,
+      "end": 493.84,
+      "text": "the"
+    },
+    {
+      "start": 493.85,
+      "end": 494.01,
+      "text": "next"
+    },
+    {
+      "start": 494,
+      "end": 494.32,
+      "text": "one,"
+    },
+    {
+      "start": 494.32,
+      "end": 494.88,
+      "text": "PLC"
+    },
+    {
+      "start": 494.88,
+      "end": 495.2,
+      "text": "or"
+    },
+    {
+      "start": 495.2,
+      "end": 495.6,
+      "text": "what"
+    },
+    {
+      "start": 495.61,
+      "end": 495.85,
+      "text": "about"
+    },
+    {
+      "start": 495.85,
+      "end": 496.09,
+      "text": "that"
+    },
+    {
+      "start": 496.08,
+      "end": 496.56,
+      "text": "centralized"
+    },
+    {
+      "start": 496.56,
+      "end": 497.04,
+      "text": "server"
+    },
+    {
+      "start": 497.05,
+      "end": 497.21,
+      "text": "at"
+    },
+    {
+      "start": 497.2,
+      "end": 497.28,
+      "text": "the"
+    },
+    {
+      "start": 497.29,
+      "end": 497.53,
+      "text": "bottom"
+    },
+    {
+      "start": 497.52,
+      "end": 497.68,
+      "text": "of"
+    },
+    {
+      "start": 497.69,
+      "end": 497.85,
+      "text": "the"
+    },
+    {
+      "start": 497.85,
+      "end": 498.41,
+      "text": "stack?"
+    },
+    {
+      "start": 499.05,
+      "end": 499.29,
+      "text": "For"
+    },
+    {
+      "start": 499.29,
+      "end": 499.53,
+      "text": "those"
+    },
+    {
+      "start": 499.52,
+      "end": 499.68,
+      "text": "that"
+    },
+    {
+      "start": 499.69,
+      "end": 499.85,
+      "text": "don't"
+    },
+    {
+      "start": 499.85,
+      "end": 500.01,
+      "text": "know,"
+    },
+    {
+      "start": 500,
+      "end": 500.4,
+      "text": "PLC"
+    },
+    {
+      "start": 500.4,
+      "end": 500.64,
+      "text": "is"
+    },
+    {
+      "start": 500.64,
+      "end": 502.4,
+      "text": "the"
+    },
+    {
+      "start": 501.76,
+      "end": 502.64,
+      "text": "identifier,"
+    },
+    {
+      "start": 502.72,
+      "end": 503.04,
+      "text": "not"
+    },
+    {
+      "start": 503.04,
+      "end": 503.68,
+      "text": "identity,"
+    },
+    {
+      "start": 503.68,
+      "end": 503.92,
+      "text": "the"
+    },
+    {
+      "start": 503.92,
+      "end": 504.48,
+      "text": "identifier"
+    },
+    {
+      "start": 504.48,
+      "end": 505.04,
+      "text": "system"
+    },
+    {
+      "start": 505.04,
+      "end": 505.36,
+      "text": "for"
+    },
+    {
+      "start": 505.36,
+      "end": 505.6,
+      "text": "the"
+    },
+    {
+      "start": 505.6,
+      "end": 505.92,
+      "text": "AT"
+    },
+    {
+      "start": 505.92,
+      "end": 506.8,
+      "text": "protocol."
+    },
+    {
+      "start": 506.88,
+      "end": 507.2,
+      "text": "It's"
+    },
+    {
+      "start": 507.2,
+      "end": 507.44,
+      "text": "where"
+    },
+    {
+      "start": 507.44,
+      "end": 508,
+      "text": "your"
+    },
+    {
+      "start": 508,
+      "end": 508.4,
+      "text": "keys"
+    },
+    {
+      "start": 508.4,
+      "end": 508.64,
+      "text": "are"
+    },
+    {
+      "start": 508.64,
+      "end": 509.28,
+      "text": "stored"
+    },
+    {
+      "start": 509.6,
+      "end": 510.24,
+      "text": "or"
+    },
+    {
+      "start": 510.32,
+      "end": 510.72,
+      "text": "yeah."
+    },
+    {
+      "start": 510.72,
+      "end": 510.96,
+      "text": "It"
+    },
+    {
+      "start": 510.96,
+      "end": 511.52,
+      "text": "describes"
+    },
+    {
+      "start": 511.52,
+      "end": 511.68,
+      "text": "your"
+    },
+    {
+      "start": 511.68,
+      "end": 511.92,
+      "text": "public"
+    },
+    {
+      "start": 511.92,
+      "end": 512.16,
+      "text": "keys"
+    },
+    {
+      "start": 512.48,
+      "end": 512.72,
+      "text": "service"
+    },
+    {
+      "start": 512.72,
+      "end": 513.44,
+      "text": "endpoints,"
+    },
+    {
+      "start": 513.6,
+      "end": 513.76,
+      "text": "and"
+    },
+    {
+      "start": 513.76,
+      "end": 515.04,
+      "text": "it's"
+    },
+    {
+      "start": 514.1,
+      "end": 514.42,
+      "text": "kind"
+    },
+    {
+      "start": 514.74,
+      "end": 515.14,
+      "text": "centralized"
+    },
+    {
+      "start": 515.13,
+      "end": 515.45,
+      "text": "server"
+    },
+    {
+      "start": 515.77,
+      "end": 515.93,
+      "text": "by"
+    },
+    {
+      "start": 516.1,
+      "end": 516.34,
+      "text": "Sky"
+    },
+    {
+      "start": 516.74,
+      "end": 517.06,
+      "text": "at"
+    },
+    {
+      "start": 517.13,
+      "end": 517.37,
+      "text": "bottom"
+    },
+    {
+      "start": 517.38,
+      "end": 517.54,
+      "text": "of"
+    },
+    {
+      "start": 517.53,
+      "end": 517.69,
+      "text": "the"
+    },
+    {
+      "start": 519.13,
+      "end": 519.37,
+      "text": "My"
+    },
+    {
+      "start": 519.38,
+      "end": 519.78,
+      "text": "outtake"
+    },
+    {
+      "start": 519.77,
+      "end": 519.85,
+      "text": "is"
+    },
+    {
+      "start": 519.86,
+      "end": 520.26,
+      "text": "PLC"
+    },
+    {
+      "start": 520.25,
+      "end": 520.49,
+      "text": "isn't"
+    },
+    {
+      "start": 520.5,
+      "end": 520.66,
+      "text": "that"
+    },
+    {
+      "start": 520.65,
+      "end": 521.05,
+      "text": "bad."
+    },
+    {
+      "start": 521.13,
+      "end": 521.37,
+      "text": "threat"
+    },
+    {
+      "start": 521.38,
+      "end": 521.7,
+      "text": "model"
+    },
+    {
+      "start": 521.86,
+      "end": 522.26,
+      "text": "actually"
+    },
+    {
+      "start": 522.25,
+      "end": 522.57,
+      "text": "pretty"
+    },
+    {
+      "start": 523.77,
+      "end": 524.25,
+      "text": "Everything"
+    },
+    {
+      "start": 524.25,
+      "end": 524.49,
+      "text": "is"
+    },
+    {
+      "start": 524.5,
+      "end": 525.3,
+      "text": "cryptographically"
+    },
+    {
+      "start": 525.29,
+      "end": 526.25,
+      "text": "signed."
+    },
+    {
+      "start": 526.33,
+      "end": 526.65,
+      "text": "The"
+    },
+    {
+      "start": 526.65,
+      "end": 526.89,
+      "text": "threat"
+    },
+    {
+      "start": 526.89,
+      "end": 527.21,
+      "text": "model"
+    },
+    {
+      "start": 527.21,
+      "end": 527.37,
+      "text": "of"
+    },
+    {
+      "start": 527.38,
+      "end": 528.34,
+      "text": "what"
+    },
+    {
+      "start": 527.81,
+      "end": 528.29,
+      "text": "whoever"
+    },
+    {
+      "start": 528.29,
+      "end": 528.45,
+      "text": "is"
+    },
+    {
+      "start": 528.45,
+      "end": 528.69,
+      "text": "running"
+    },
+    {
+      "start": 528.69,
+      "end": 528.77,
+      "text": "the"
+    },
+    {
+      "start": 528.77,
+      "end": 529.17,
+      "text": "PLC"
+    },
+    {
+      "start": 529.17,
+      "end": 529.73,
+      "text": "directory,"
+    },
+    {
+      "start": 529.73,
+      "end": 529.81,
+      "text": "what"
+    },
+    {
+      "start": 529.81,
+      "end": 529.97,
+      "text": "they"
+    },
+    {
+      "start": 529.97,
+      "end": 530.05,
+      "text": "can"
+    },
+    {
+      "start": 530.05,
+      "end": 530.21,
+      "text": "get"
+    },
+    {
+      "start": 530.21,
+      "end": 530.45,
+      "text": "away"
+    },
+    {
+      "start": 530.45,
+      "end": 530.85,
+      "text": "with"
+    },
+    {
+      "start": 530.85,
+      "end": 531.17,
+      "text": "is"
+    },
+    {
+      "start": 531.17,
+      "end": 531.49,
+      "text": "not"
+    },
+    {
+      "start": 531.49,
+      "end": 531.65,
+      "text": "that"
+    },
+    {
+      "start": 531.65,
+      "end": 531.97,
+      "text": "much."
+    },
+    {
+      "start": 531.97,
+      "end": 532.13,
+      "text": "They"
+    },
+    {
+      "start": 532.13,
+      "end": 532.37,
+      "text": "can't"
+    },
+    {
+      "start": 532.37,
+      "end": 533.01,
+      "text": "arbitrarily"
+    },
+    {
+      "start": 533.01,
+      "end": 533.25,
+      "text": "change"
+    },
+    {
+      "start": 533.25,
+      "end": 533.49,
+      "text": "your"
+    },
+    {
+      "start": 533.49,
+      "end": 533.73,
+      "text": "identity"
+    },
+    {
+      "start": 533.73,
+      "end": 533.97,
+      "text": "or"
+    },
+    {
+      "start": 533.97,
+      "end": 534.29,
+      "text": "anything"
+    },
+    {
+      "start": 534.29,
+      "end": 534.53,
+      "text": "like"
+    },
+    {
+      "start": 534.53,
+      "end": 534.93,
+      "text": "that."
+    },
+    {
+      "start": 534.93,
+      "end": 535.09,
+      "text": "They"
+    },
+    {
+      "start": 535.09,
+      "end": 535.25,
+      "text": "can"
+    },
+    {
+      "start": 535.25,
+      "end": 535.65,
+      "text": "essentially"
+    },
+    {
+      "start": 535.65,
+      "end": 535.81,
+      "text": "do"
+    },
+    {
+      "start": 535.81,
+      "end": 536.21,
+      "text": "denial"
+    },
+    {
+      "start": 536.21,
+      "end": 536.45,
+      "text": "of"
+    },
+    {
+      "start": 536.45,
+      "end": 536.69,
+      "text": "service"
+    },
+    {
+      "start": 536.69,
+      "end": 537.33,
+      "text": "attacks,"
+    },
+    {
+      "start": 537.33,
+      "end": 537.81,
+      "text": "removing"
+    },
+    {
+      "start": 537.81,
+      "end": 538.61,
+      "text": "operations"
+    },
+    {
+      "start": 538.61,
+      "end": 538.85,
+      "text": "from"
+    },
+    {
+      "start": 538.85,
+      "end": 539.09,
+      "text": "your"
+    },
+    {
+      "start": 539.09,
+      "end": 539.73,
+      "text": "identity,"
+    },
+    {
+      "start": 539.73,
+      "end": 539.81,
+      "text": "or"
+    },
+    {
+      "start": 539.81,
+      "end": 540.29,
+      "text": "refusing"
+    },
+    {
+      "start": 540.29,
+      "end": 540.45,
+      "text": "to"
+    },
+    {
+      "start": 540.45,
+      "end": 540.69,
+      "text": "serve"
+    },
+    {
+      "start": 540.69,
+      "end": 540.93,
+      "text": "your"
+    },
+    {
+      "start": 540.93,
+      "end": 541.25,
+      "text": "identity."
+    },
+    {
+      "start": 542.34,
+      "end": 542.66,
+      "text": "Those"
+    },
+    {
+      "start": 542.65,
+      "end": 542.89,
+      "text": "aren't"
+    },
+    {
+      "start": 542.89,
+      "end": 543.45,
+      "text": "good,"
+    },
+    {
+      "start": 543.53,
+      "end": 543.69,
+      "text": "but"
+    },
+    {
+      "start": 543.7,
+      "end": 544.02,
+      "text": "just"
+    },
+    {
+      "start": 544.01,
+      "end": 544.17,
+      "text": "to"
+    },
+    {
+      "start": 544.17,
+      "end": 544.33,
+      "text": "note"
+    },
+    {
+      "start": 544.34,
+      "end": 544.5,
+      "text": "the"
+    },
+    {
+      "start": 544.5,
+      "end": 544.66,
+      "text": "threat"
+    },
+    {
+      "start": 544.65,
+      "end": 545.05,
+      "text": "model"
+    },
+    {
+      "start": 545.05,
+      "end": 545.45,
+      "text": "is"
+    },
+    {
+      "start": 545.46,
+      "end": 545.78,
+      "text": "pretty"
+    },
+    {
+      "start": 545.77,
+      "end": 546.41,
+      "text": "limited."
+    },
+    {
+      "start": 546.89,
+      "end": 547.13,
+      "text": "All"
+    },
+    {
+      "start": 547.13,
+      "end": 547.29,
+      "text": "that"
+    },
+    {
+      "start": 547.29,
+      "end": 547.45,
+      "text": "being"
+    },
+    {
+      "start": 547.46,
+      "end": 547.78,
+      "text": "said,"
+    },
+    {
+      "start": 547.77,
+      "end": 547.85,
+      "text": "it"
+    },
+    {
+      "start": 547.86,
+      "end": 548.02,
+      "text": "still"
+    },
+    {
+      "start": 548.01,
+      "end": 548.25,
+      "text": "needs"
+    },
+    {
+      "start": 548.25,
+      "end": 548.41,
+      "text": "some"
+    },
+    {
+      "start": 548.41,
+      "end": 548.97,
+      "text": "work."
+    },
+    {
+      "start": 549.38,
+      "end": 549.54,
+      "text": "And"
+    },
+    {
+      "start": 549.53,
+      "end": 549.93,
+      "text": "so,"
+    },
+    {
+      "start": 549.93,
+      "end": 550.17,
+      "text": "we're"
+    },
+    {
+      "start": 550.17,
+      "end": 550.33,
+      "text": "sort"
+    },
+    {
+      "start": 550.34,
+      "end": 550.5,
+      "text": "of"
+    },
+    {
+      "start": 550.5,
+      "end": 550.74,
+      "text": "thinking"
+    },
+    {
+      "start": 550.74,
+      "end": 551.3,
+      "text": "about"
+    },
+    {
+      "start": 551.86,
+      "end": 552.34,
+      "text": "maturing"
+    },
+    {
+      "start": 552.34,
+      "end": 552.98,
+      "text": "governance"
+    },
+    {
+      "start": 552.98,
+      "end": 553.22,
+      "text": "of"
+    },
+    {
+      "start": 553.22,
+      "end": 553.94,
+      "text": "PLC"
+    },
+    {
+      "start": 553.93,
+      "end": 554.17,
+      "text": "as"
+    },
+    {
+      "start": 554.17,
+      "end": 554.33,
+      "text": "we"
+    },
+    {
+      "start": 554.34,
+      "end": 554.5,
+      "text": "go"
+    },
+    {
+      "start": 554.5,
+      "end": 554.74,
+      "text": "along."
+    },
+    {
+      "start": 555.12,
+      "end": 555.52,
+      "text": "We'd"
+    },
+    {
+      "start": 555.52,
+      "end": 555.6,
+      "text": "like"
+    },
+    {
+      "start": 555.6,
+      "end": 555.68,
+      "text": "to"
+    },
+    {
+      "start": 555.68,
+      "end": 555.84,
+      "text": "use"
+    },
+    {
+      "start": 555.84,
+      "end": 556.32,
+      "text": "DNS"
+    },
+    {
+      "start": 556.32,
+      "end": 556.56,
+      "text": "and"
+    },
+    {
+      "start": 556.56,
+      "end": 557.04,
+      "text": "ICANN"
+    },
+    {
+      "start": 557.04,
+      "end": 557.2,
+      "text": "as"
+    },
+    {
+      "start": 557.2,
+      "end": 557.36,
+      "text": "an"
+    },
+    {
+      "start": 557.36,
+      "end": 558,
+      "text": "example."
+    },
+    {
+      "start": 559.12,
+      "end": 559.6,
+      "text": "Mostly"
+    },
+    {
+      "start": 559.6,
+      "end": 559.84,
+      "text": "for"
+    },
+    {
+      "start": 559.84,
+      "end": 560,
+      "text": "an"
+    },
+    {
+      "start": 560,
+      "end": 560.4,
+      "text": "analogy"
+    },
+    {
+      "start": 560.4,
+      "end": 560.64,
+      "text": "of"
+    },
+    {
+      "start": 560.64,
+      "end": 561.2,
+      "text": "iterative"
+    },
+    {
+      "start": 561.2,
+      "end": 561.68,
+      "text": "maturation"
+    },
+    {
+      "start": 561.68,
+      "end": 561.84,
+      "text": "of"
+    },
+    {
+      "start": 561.84,
+      "end": 562.48,
+      "text": "governance."
+    },
+    {
+      "start": 562.48,
+      "end": 562.96,
+      "text": "DNS"
+    },
+    {
+      "start": 562.96,
+      "end": 563.6,
+      "text": "has"
+    },
+    {
+      "start": 563.6,
+      "end": 564,
+      "text": "issues."
+    },
+    {
+      "start": 564,
+      "end": 564.48,
+      "text": "ICANN"
+    },
+    {
+      "start": 564.48,
+      "end": 564.64,
+      "text": "has"
+    },
+    {
+      "start": 564.64,
+      "end": 565.04,
+      "text": "issues."
+    },
+    {
+      "start": 565.04,
+      "end": 565.2,
+      "text": "Don't"
+    },
+    {
+      "start": 565.2,
+      "end": 565.52,
+      "text": "overthink"
+    },
+    {
+      "start": 565.52,
+      "end": 565.76,
+      "text": "the"
+    },
+    {
+      "start": 565.76,
+      "end": 566.4,
+      "text": "analogy."
+    },
+    {
+      "start": 566.64,
+      "end": 566.72,
+      "text": "But"
+    },
+    {
+      "start": 566.72,
+      "end": 566.88,
+      "text": "you"
+    },
+    {
+      "start": 566.88,
+      "end": 567.04,
+      "text": "can"
+    },
+    {
+      "start": 567.04,
+      "end": 567.2,
+      "text": "kind"
+    },
+    {
+      "start": 567.2,
+      "end": 567.36,
+      "text": "of"
+    },
+    {
+      "start": 567.36,
+      "end": 567.52,
+      "text": "see"
+    },
+    {
+      "start": 567.52,
+      "end": 567.76,
+      "text": "how"
+    },
+    {
+      "start": 567.76,
+      "end": 568.16,
+      "text": "DNS"
+    },
+    {
+      "start": 568.16,
+      "end": 568.64,
+      "text": "evolved"
+    },
+    {
+      "start": 568.64,
+      "end": 568.88,
+      "text": "over"
+    },
+    {
+      "start": 568.88,
+      "end": 569.36,
+      "text": "time."
+    },
+    {
+      "start": 569.52,
+      "end": 569.92,
+      "text": "It"
+    },
+    {
+      "start": 569.57,
+      "end": 570.05,
+      "text": "Started"
+    },
+    {
+      "start": 570.04,
+      "end": 570.2,
+      "text": "as"
+    },
+    {
+      "start": 570.21,
+      "end": 570.29,
+      "text": "a"
+    },
+    {
+      "start": 570.28,
+      "end": 570.52,
+      "text": "text"
+    },
+    {
+      "start": 570.52,
+      "end": 570.84,
+      "text": "file"
+    },
+    {
+      "start": 570.85,
+      "end": 571.17,
+      "text": "that"
+    },
+    {
+      "start": 571.16,
+      "end": 571.32,
+      "text": "got"
+    },
+    {
+      "start": 571.33,
+      "end": 571.89,
+      "text": "distributed"
+    },
+    {
+      "start": 571.88,
+      "end": 572.44,
+      "text": "to"
+    },
+    {
+      "start": 572.61,
+      "end": 573.01,
+      "text": "different"
+    },
+    {
+      "start": 573,
+      "end": 573.24,
+      "text": "hosts"
+    },
+    {
+      "start": 573.25,
+      "end": 573.41,
+      "text": "in"
+    },
+    {
+      "start": 573.4,
+      "end": 573.48,
+      "text": "the"
+    },
+    {
+      "start": 573.49,
+      "end": 574.05,
+      "text": "network,"
+    },
+    {
+      "start": 574.04,
+      "end": 574.36,
+      "text": "moved"
+    },
+    {
+      "start": 574.37,
+      "end": 574.69,
+      "text": "to"
+    },
+    {
+      "start": 574.68,
+      "end": 575,
+      "text": "a"
+    },
+    {
+      "start": 575,
+      "end": 575.32,
+      "text": "single"
+    },
+    {
+      "start": 575.33,
+      "end": 575.65,
+      "text": "server"
+    },
+    {
+      "start": 575.64,
+      "end": 575.8,
+      "text": "that"
+    },
+    {
+      "start": 575.8,
+      "end": 575.96,
+      "text": "was"
+    },
+    {
+      "start": 575.97,
+      "end": 576.13,
+      "text": "a"
+    },
+    {
+      "start": 576.13,
+      "end": 576.45,
+      "text": "computer"
+    },
+    {
+      "start": 576.45,
+      "end": 576.69,
+      "text": "under"
+    },
+    {
+      "start": 576.68,
+      "end": 576.84,
+      "text": "the"
+    },
+    {
+      "start": 576.85,
+      "end": 577.41,
+      "text": "desk,"
+    },
+    {
+      "start": 577.57,
+      "end": 577.97,
+      "text": "transitioned"
+    },
+    {
+      "start": 577.97,
+      "end": 578.21,
+      "text": "to"
+    },
+    {
+      "start": 578.21,
+      "end": 578.53,
+      "text": "multiple"
+    },
+    {
+      "start": 578.52,
+      "end": 578.76,
+      "text": "root"
+    },
+    {
+      "start": 578.76,
+      "end": 579.48,
+      "text": "servers."
+    },
+    {
+      "start": 579.64,
+      "end": 580.04,
+      "text": "ICANN"
+    },
+    {
+      "start": 580.04,
+      "end": 580.28,
+      "text": "got"
+    },
+    {
+      "start": 580.28,
+      "end": 580.52,
+      "text": "set"
+    },
+    {
+      "start": 580.52,
+      "end": 580.76,
+      "text": "up"
+    },
+    {
+      "start": 580.76,
+      "end": 581.08,
+      "text": "as"
+    },
+    {
+      "start": 581.09,
+      "end": 581.25,
+      "text": "a"
+    },
+    {
+      "start": 581.25,
+      "end": 581.65,
+      "text": "governance"
+    },
+    {
+      "start": 581.64,
+      "end": 582.04,
+      "text": "body"
+    },
+    {
+      "start": 582.04,
+      "end": 582.2,
+      "text": "for"
+    },
+    {
+      "start": 582.21,
+      "end": 582.37,
+      "text": "it"
+    },
+    {
+      "start": 582.37,
+      "end": 582.77,
+      "text": "and"
+    },
+    {
+      "start": 582.76,
+      "end": 583.32,
+      "text": "ICANN"
+    },
+    {
+      "start": 583.33,
+      "end": 584.13,
+      "text": "continues"
+    },
+    {
+      "start": 584.5,
+      "end": 584.82,
+      "text": "to"
+    },
+    {
+      "start": 584.82,
+      "end": 585.22,
+      "text": "evolve"
+    },
+    {
+      "start": 585.22,
+      "end": 585.46,
+      "text": "in"
+    },
+    {
+      "start": 585.46,
+      "end": 585.62,
+      "text": "their"
+    },
+    {
+      "start": 585.62,
+      "end": 586.26,
+      "text": "governance,"
+    },
+    {
+      "start": 586.74,
+      "end": 586.82,
+      "text": "being"
+    },
+    {
+      "start": 586.82,
+      "end": 587.06,
+      "text": "more"
+    },
+    {
+      "start": 587.06,
+      "end": 587.14,
+      "text": "and"
+    },
+    {
+      "start": 587.14,
+      "end": 587.3,
+      "text": "more"
+    },
+    {
+      "start": 587.3,
+      "end": 587.54,
+      "text": "multi"
+    },
+    {
+      "start": 587.54,
+      "end": 588.26,
+      "text": "stakeholder,"
+    },
+    {
+      "start": 588.26,
+      "end": 588.42,
+      "text": "taking"
+    },
+    {
+      "start": 588.42,
+      "end": 588.66,
+      "text": "into"
+    },
+    {
+      "start": 588.66,
+      "end": 588.98,
+      "text": "account"
+    },
+    {
+      "start": 588.98,
+      "end": 589.22,
+      "text": "other"
+    },
+    {
+      "start": 589.22,
+      "end": 589.54,
+      "text": "countries"
+    },
+    {
+      "start": 589.54,
+      "end": 589.86,
+      "text": "outside"
+    },
+    {
+      "start": 589.86,
+      "end": 589.94,
+      "text": "of"
+    },
+    {
+      "start": 589.94,
+      "end": 590.1,
+      "text": "The"
+    },
+    {
+      "start": 590.1,
+      "end": 590.34,
+      "text": "US"
+    },
+    {
+      "start": 590.34,
+      "end": 590.98,
+      "text": "more."
+    },
+    {
+      "start": 592.02,
+      "end": 592.18,
+      "text": "And"
+    },
+    {
+      "start": 592.18,
+      "end": 592.5,
+      "text": "so,"
+    },
+    {
+      "start": 592.5,
+      "end": 592.58,
+      "text": "this"
+    },
+    {
+      "start": 592.58,
+      "end": 592.74,
+      "text": "is"
+    },
+    {
+      "start": 592.74,
+      "end": 592.9,
+      "text": "sort"
+    },
+    {
+      "start": 592.9,
+      "end": 592.98,
+      "text": "of"
+    },
+    {
+      "start": 592.98,
+      "end": 593.06,
+      "text": "the"
+    },
+    {
+      "start": 593.06,
+      "end": 593.3,
+      "text": "model"
+    },
+    {
+      "start": 593.3,
+      "end": 593.46,
+      "text": "that"
+    },
+    {
+      "start": 593.46,
+      "end": 593.62,
+      "text": "we"
+    },
+    {
+      "start": 593.62,
+      "end": 593.7,
+      "text": "look"
+    },
+    {
+      "start": 593.7,
+      "end": 593.86,
+      "text": "at"
+    },
+    {
+      "start": 593.86,
+      "end": 594.02,
+      "text": "with"
+    },
+    {
+      "start": 594.02,
+      "end": 594.5,
+      "text": "PLC"
+    },
+    {
+      "start": 594.5,
+      "end": 595.22,
+      "text": "is,"
+    },
+    {
+      "start": 596.02,
+      "end": 596.26,
+      "text": "you"
+    },
+    {
+      "start": 596.26,
+      "end": 596.42,
+      "text": "know,"
+    },
+    {
+      "start": 596.42,
+      "end": 596.58,
+      "text": "like"
+    },
+    {
+      "start": 596.58,
+      "end": 596.74,
+      "text": "we"
+    },
+    {
+      "start": 596.74,
+      "end": 596.98,
+      "text": "don't"
+    },
+    {
+      "start": 596.98,
+      "end": 597.06,
+      "text": "have"
+    },
+    {
+      "start": 597.06,
+      "end": 597.14,
+      "text": "to"
+    },
+    {
+      "start": 597.14,
+      "end": 597.3,
+      "text": "get"
+    },
+    {
+      "start": 597.3,
+      "end": 597.38,
+      "text": "it"
+    },
+    {
+      "start": 597.38,
+      "end": 597.54,
+      "text": "to"
+    },
+    {
+      "start": 597.54,
+      "end": 597.7,
+      "text": "the"
+    },
+    {
+      "start": 597.7,
+      "end": 597.86,
+      "text": "end"
+    },
+    {
+      "start": 597.86,
+      "end": 598.18,
+      "text": "state"
+    },
+    {
+      "start": 598.18,
+      "end": 598.42,
+      "text": "of"
+    },
+    {
+      "start": 598.42,
+      "end": 598.74,
+      "text": "like,"
+    },
+    {
+      "start": 598.74,
+      "end": 598.82,
+      "text": "this"
+    },
+    {
+      "start": 598.82,
+      "end": 598.98,
+      "text": "is"
+    },
+    {
+      "start": 598.98,
+      "end": 599.06,
+      "text": "the"
+    },
+    {
+      "start": 599.06,
+      "end": 599.62,
+      "text": "perfect"
+    },
+    {
+      "start": 599.36,
+      "end": 599.84,
+      "text": "PLC"
+    },
+    {
+      "start": 599.83,
+      "end": 600.23,
+      "text": "forever"
+    },
+    {
+      "start": 600.24,
+      "end": 600.48,
+      "text": "or"
+    },
+    {
+      "start": 600.48,
+      "end": 600.72,
+      "text": "something"
+    },
+    {
+      "start": 600.71,
+      "end": 601.43,
+      "text": "tomorrow."
+    },
+    {
+      "start": 601.43,
+      "end": 601.59,
+      "text": "It's"
+    },
+    {
+      "start": 601.6,
+      "end": 601.92,
+      "text": "how"
+    },
+    {
+      "start": 601.91,
+      "end": 601.99,
+      "text": "can"
+    },
+    {
+      "start": 602,
+      "end": 602.16,
+      "text": "we"
+    },
+    {
+      "start": 602.15,
+      "end": 603.11,
+      "text": "iteratively"
+    },
+    {
+      "start": 603.2,
+      "end": 603.52,
+      "text": "move"
+    },
+    {
+      "start": 603.51,
+      "end": 603.67,
+      "text": "that"
+    },
+    {
+      "start": 603.67,
+      "end": 604.07,
+      "text": "forward"
+    },
+    {
+      "start": 604.07,
+      "end": 604.39,
+      "text": "as"
+    },
+    {
+      "start": 604.39,
+      "end": 604.55,
+      "text": "the"
+    },
+    {
+      "start": 604.55,
+      "end": 604.87,
+      "text": "like"
+    },
+    {
+      "start": 604.88,
+      "end": 605.12,
+      "text": "kind"
+    },
+    {
+      "start": 605.12,
+      "end": 605.2,
+      "text": "of"
+    },
+    {
+      "start": 605.2,
+      "end": 605.44,
+      "text": "threat"
+    },
+    {
+      "start": 605.43,
+      "end": 605.83,
+      "text": "model"
+    },
+    {
+      "start": 605.83,
+      "end": 606.07,
+      "text": "for"
+    },
+    {
+      "start": 606.07,
+      "end": 606.23,
+      "text": "the"
+    },
+    {
+      "start": 606.24,
+      "end": 606.8,
+      "text": "atmosphere"
+    },
+    {
+      "start": 606.79,
+      "end": 607.67,
+      "text": "evolves."
+    },
+    {
+      "start": 608.24,
+      "end": 608.48,
+      "text": "So"
+    },
+    {
+      "start": 608.48,
+      "end": 608.8,
+      "text": "the"
+    },
+    {
+      "start": 608.79,
+      "end": 609.19,
+      "text": "exciting"
+    },
+    {
+      "start": 609.2,
+      "end": 609.44,
+      "text": "news"
+    },
+    {
+      "start": 609.43,
+      "end": 609.59,
+      "text": "to"
+    },
+    {
+      "start": 609.6,
+      "end": 609.84,
+      "text": "announce"
+    },
+    {
+      "start": 609.83,
+      "end": 610.07,
+      "text": "is"
+    },
+    {
+      "start": 610.07,
+      "end": 610.47,
+      "text": "that"
+    },
+    {
+      "start": 610.48,
+      "end": 610.96,
+      "text": "public"
+    },
+    {
+      "start": 610.95,
+      "end": 611.27,
+      "text": "ledger"
+    },
+    {
+      "start": 611.27,
+      "end": 611.43,
+      "text": "of"
+    },
+    {
+      "start": 611.43,
+      "end": 611.83,
+      "text": "credentials"
+    },
+    {
+      "start": 611.83,
+      "end": 612.55,
+      "text": "organization"
+    },
+    {
+      "start": 612.55,
+      "end": 612.87,
+      "text": "has"
+    },
+    {
+      "start": 612.88,
+      "end": 613.2,
+      "text": "officially"
+    },
+    {
+      "start": 613.2,
+      "end": 613.44,
+      "text": "been"
+    },
+    {
+      "start": 613.43,
+      "end": 613.75,
+      "text": "founded"
+    },
+    {
+      "start": 613.75,
+      "end": 613.99,
+      "text": "as"
+    },
+    {
+      "start": 614,
+      "end": 615.2,
+      "text": "a"
+    },
+    {
+      "start": 614.22,
+      "end": 614.62,
+      "text": "Swiss"
+    },
+    {
+      "start": 614.62,
+      "end": 615.66,
+      "text": "association."
+    },
+    {
+      "start": 622.62,
+      "end": 623.02,
+      "text": "Again,"
+    },
+    {
+      "start": 623.02,
+      "end": 623.34,
+      "text": "huge"
+    },
+    {
+      "start": 623.34,
+      "end": 623.74,
+      "text": "kudos"
+    },
+    {
+      "start": 623.74,
+      "end": 623.9,
+      "text": "to"
+    },
+    {
+      "start": 623.9,
+      "end": 624.22,
+      "text": "Brian"
+    },
+    {
+      "start": 624.22,
+      "end": 624.46,
+      "text": "for"
+    },
+    {
+      "start": 624.46,
+      "end": 624.7,
+      "text": "leading"
+    },
+    {
+      "start": 624.7,
+      "end": 624.94,
+      "text": "this"
+    },
+    {
+      "start": 624.94,
+      "end": 625.26,
+      "text": "up,"
+    },
+    {
+      "start": 625.26,
+      "end": 625.34,
+      "text": "as"
+    },
+    {
+      "start": 625.34,
+      "end": 625.5,
+      "text": "well"
+    },
+    {
+      "start": 625.5,
+      "end": 625.58,
+      "text": "as"
+    },
+    {
+      "start": 625.58,
+      "end": 625.98,
+      "text": "Matt,"
+    },
+    {
+      "start": 625.98,
+      "end": 626.14,
+      "text": "our"
+    },
+    {
+      "start": 626.14,
+      "end": 626.3,
+      "text": "head"
+    },
+    {
+      "start": 626.3,
+      "end": 626.46,
+      "text": "of"
+    },
+    {
+      "start": 626.46,
+      "end": 626.7,
+      "text": "legal,"
+    },
+    {
+      "start": 626.89,
+      "end": 627.21,
+      "text": "which"
+    },
+    {
+      "start": 627.22,
+      "end": 627.38,
+      "text": "if"
+    },
+    {
+      "start": 627.38,
+      "end": 627.54,
+      "text": "you"
+    },
+    {
+      "start": 627.54,
+      "end": 627.62,
+      "text": "guys"
+    },
+    {
+      "start": 627.62,
+      "end": 627.78,
+      "text": "can"
+    },
+    {
+      "start": 627.77,
+      "end": 627.93,
+      "text": "find"
+    },
+    {
+      "start": 628.1,
+      "end": 628.18,
+      "text": "I"
+    },
+    {
+      "start": 628.18,
+      "end": 628.26,
+      "text": "don't"
+    },
+    {
+      "start": 628.25,
+      "end": 628.33,
+      "text": "know"
+    },
+    {
+      "start": 628.34,
+      "end": 628.5,
+      "text": "if"
+    },
+    {
+      "start": 628.5,
+      "end": 628.74,
+      "text": "Matt's"
+    },
+    {
+      "start": 628.74,
+      "end": 628.98,
+      "text": "here."
+    },
+    {
+      "start": 628.98,
+      "end": 629.06,
+      "text": "But"
+    },
+    {
+      "start": 629.05,
+      "end": 629.21,
+      "text": "if"
+    },
+    {
+      "start": 629.22,
+      "end": 629.3,
+      "text": "you"
+    },
+    {
+      "start": 629.3,
+      "end": 629.46,
+      "text": "guys"
+    },
+    {
+      "start": 629.46,
+      "end": 629.62,
+      "text": "can"
+    },
+    {
+      "start": 629.62,
+      "end": 629.78,
+      "text": "find"
+    },
+    {
+      "start": 629.77,
+      "end": 630.01,
+      "text": "Matt,"
+    },
+    {
+      "start": 630.01,
+      "end": 630.09,
+      "text": "you"
+    },
+    {
+      "start": 630.1,
+      "end": 630.26,
+      "text": "should"
+    },
+    {
+      "start": 630.25,
+      "end": 630.41,
+      "text": "try"
+    },
+    {
+      "start": 630.58,
+      "end": 630.74,
+      "text": "talk"
+    },
+    {
+      "start": 630.74,
+      "end": 630.82,
+      "text": "to"
+    },
+    {
+      "start": 630.82,
+      "end": 631.14,
+      "text": "Matt."
+    },
+    {
+      "start": 631.13,
+      "end": 631.29,
+      "text": "He's"
+    },
+    {
+      "start": 631.3,
+      "end": 631.46,
+      "text": "like"
+    },
+    {
+      "start": 631.46,
+      "end": 631.86,
+      "text": "protocol"
+    },
+    {
+      "start": 631.86,
+      "end": 632.26,
+      "text": "pilled"
+    },
+    {
+      "start": 632.25,
+      "end": 632.41,
+      "text": "now."
+    },
+    {
+      "start": 632.42,
+      "end": 632.58,
+      "text": "It's"
+    },
+    {
+      "start": 632.58,
+      "end": 632.74,
+      "text": "very"
+    },
+    {
+      "start": 632.74,
+      "end": 633.22,
+      "text": "fun."
+    },
+    {
+      "start": 634.5,
+      "end": 634.74,
+      "text": "So"
+    },
+    {
+      "start": 634.74,
+      "end": 634.98,
+      "text": "we"
+    },
+    {
+      "start": 634.98,
+      "end": 635.22,
+      "text": "put"
+    },
+    {
+      "start": 635.22,
+      "end": 635.3,
+      "text": "a"
+    },
+    {
+      "start": 635.3,
+      "end": 635.46,
+      "text": "lot"
+    },
+    {
+      "start": 635.46,
+      "end": 635.54,
+      "text": "of"
+    },
+    {
+      "start": 635.54,
+      "end": 635.78,
+      "text": "thought"
+    },
+    {
+      "start": 635.77,
+      "end": 636.25,
+      "text": "into"
+    },
+    {
+      "start": 636.25,
+      "end": 636.57,
+      "text": "who"
+    },
+    {
+      "start": 636.58,
+      "end": 636.74,
+      "text": "is"
+    },
+    {
+      "start": 636.74,
+      "end": 636.9,
+      "text": "going"
+    },
+    {
+      "start": 636.89,
+      "end": 637.05,
+      "text": "to"
+    },
+    {
+      "start": 637.05,
+      "end": 637.29,
+      "text": "be"
+    },
+    {
+      "start": 637.3,
+      "end": 637.54,
+      "text": "on"
+    },
+    {
+      "start": 637.54,
+      "end": 637.62,
+      "text": "the"
+    },
+    {
+      "start": 637.62,
+      "end": 637.86,
+      "text": "board"
+    },
+    {
+      "start": 637.86,
+      "end": 638.5,
+      "text": "for"
+    },
+    {
+      "start": 639.22,
+      "end": 640.18,
+      "text": "PLC."
+    },
+    {
+      "start": 640.18,
+      "end": 640.42,
+      "text": "Like,"
+    },
+    {
+      "start": 640.42,
+      "end": 640.5,
+      "text": "we"
+    },
+    {
+      "start": 640.5,
+      "end": 640.74,
+      "text": "we"
+    },
+    {
+      "start": 640.74,
+      "end": 641.06,
+      "text": "wanted"
+    },
+    {
+      "start": 641.05,
+      "end": 641.21,
+      "text": "a"
+    },
+    {
+      "start": 641.22,
+      "end": 641.38,
+      "text": "board"
+    },
+    {
+      "start": 641.38,
+      "end": 641.7,
+      "text": "that"
+    },
+    {
+      "start": 641.93,
+      "end": 642.25,
+      "text": "people"
+    },
+    {
+      "start": 642.25,
+      "end": 642.41,
+      "text": "in"
+    },
+    {
+      "start": 642.41,
+      "end": 642.57,
+      "text": "the"
+    },
+    {
+      "start": 642.57,
+      "end": 643.37,
+      "text": "ecosystem"
+    },
+    {
+      "start": 643.45,
+      "end": 643.77,
+      "text": "could"
+    },
+    {
+      "start": 643.77,
+      "end": 644.09,
+      "text": "really"
+    },
+    {
+      "start": 644.09,
+      "end": 644.65,
+      "text": "trust"
+    },
+    {
+      "start": 645.29,
+      "end": 645.61,
+      "text": "to"
+    },
+    {
+      "start": 645.61,
+      "end": 645.93,
+      "text": "run"
+    },
+    {
+      "start": 645.93,
+      "end": 646.17,
+      "text": "this"
+    },
+    {
+      "start": 646.17,
+      "end": 646.41,
+      "text": "thing."
+    },
+    {
+      "start": 646.41,
+      "end": 646.57,
+      "text": "And"
+    },
+    {
+      "start": 646.57,
+      "end": 646.65,
+      "text": "I"
+    },
+    {
+      "start": 646.65,
+      "end": 646.81,
+      "text": "think"
+    },
+    {
+      "start": 646.81,
+      "end": 646.97,
+      "text": "that"
+    },
+    {
+      "start": 646.97,
+      "end": 647.13,
+      "text": "we"
+    },
+    {
+      "start": 647.13,
+      "end": 647.45,
+      "text": "found"
+    },
+    {
+      "start": 647.45,
+      "end": 647.69,
+      "text": "the"
+    },
+    {
+      "start": 647.69,
+      "end": 648.01,
+      "text": "perfect"
+    },
+    {
+      "start": 648.01,
+      "end": 648.49,
+      "text": "one,"
+    },
+    {
+      "start": 648.49,
+      "end": 648.57,
+      "text": "which"
+    },
+    {
+      "start": 648.57,
+      "end": 648.73,
+      "text": "is"
+    },
+    {
+      "start": 648.89,
+      "end": 649.05,
+      "text": "it's"
+    },
+    {
+      "start": 649.05,
+      "end": 649.21,
+      "text": "just"
+    },
+    {
+      "start": 649.21,
+      "end": 649.37,
+      "text": "gonna"
+    },
+    {
+      "start": 649.37,
+      "end": 649.53,
+      "text": "be"
+    },
+    {
+      "start": 649.53,
+      "end": 650.09,
+      "text": "Roscoe."
+    },
+    {
+      "start": 650.09,
+      "end": 650.17,
+      "text": "I"
+    },
+    {
+      "start": 650.17,
+      "end": 650.65,
+      "text": "think"
+    },
+    {
+      "start": 652.01,
+      "end": 652.33,
+      "text": "I"
+    },
+    {
+      "start": 652.33,
+      "end": 652.65,
+      "text": "think"
+    },
+    {
+      "start": 652.65,
+      "end": 653.45,
+      "text": "Roscoe"
+    },
+    {
+      "start": 653.45,
+      "end": 653.61,
+      "text": "is"
+    },
+    {
+      "start": 653.61,
+      "end": 653.77,
+      "text": "just"
+    },
+    {
+      "start": 653.77,
+      "end": 654.01,
+      "text": "gonna"
+    },
+    {
+      "start": 654.01,
+      "end": 654.25,
+      "text": "run"
+    },
+    {
+      "start": 654.25,
+      "end": 654.49,
+      "text": "this."
+    },
+    {
+      "start": 656.64,
+      "end": 656.96,
+      "text": "No."
+    },
+    {
+      "start": 656.97,
+      "end": 657.13,
+      "text": "I'm"
+    },
+    {
+      "start": 657.13,
+      "end": 657.37,
+      "text": "kidding"
+    },
+    {
+      "start": 657.37,
+      "end": 657.53,
+      "text": "about"
+    },
+    {
+      "start": 657.52,
+      "end": 657.84,
+      "text": "that."
+    },
+    {
+      "start": 657.85,
+      "end": 658.01,
+      "text": "This"
+    },
+    {
+      "start": 658,
+      "end": 658.08,
+      "text": "is"
+    },
+    {
+      "start": 658.09,
+      "end": 658.41,
+      "text": "this"
+    },
+    {
+      "start": 658.4,
+      "end": 658.56,
+      "text": "is"
+    },
+    {
+      "start": 658.57,
+      "end": 658.73,
+      "text": "going"
+    },
+    {
+      "start": 658.73,
+      "end": 658.81,
+      "text": "to"
+    },
+    {
+      "start": 658.8,
+      "end": 658.96,
+      "text": "be"
+    },
+    {
+      "start": 658.97,
+      "end": 659.13,
+      "text": "the"
+    },
+    {
+      "start": 659.13,
+      "end": 659.45,
+      "text": "actual"
+    },
+    {
+      "start": 659.45,
+      "end": 660.01,
+      "text": "board"
+    },
+    {
+      "start": 660.16,
+      "end": 660.48,
+      "text": "for"
+    },
+    {
+      "start": 660.49,
+      "end": 660.65,
+      "text": "the"
+    },
+    {
+      "start": 660.64,
+      "end": 661.04,
+      "text": "PLC"
+    },
+    {
+      "start": 661.04,
+      "end": 662,
+      "text": "Association."
+    },
+    {
+      "start": 662.16,
+      "end": 662.48,
+      "text": "There's"
+    },
+    {
+      "start": 662.49,
+      "end": 662.81,
+      "text": "five"
+    },
+    {
+      "start": 662.8,
+      "end": 663.44,
+      "text": "members."
+    },
+    {
+      "start": 663.92,
+      "end": 664.8,
+      "text": "Brian,"
+    },
+    {
+      "start": 664.8,
+      "end": 664.88,
+      "text": "who"
+    },
+    {
+      "start": 664.88,
+      "end": 665.04,
+      "text": "is"
+    },
+    {
+      "start": 665.04,
+      "end": 665.2,
+      "text": "on"
+    },
+    {
+      "start": 665.21,
+      "end": 665.37,
+      "text": "the"
+    },
+    {
+      "start": 665.37,
+      "end": 665.53,
+      "text": "Blue"
+    },
+    {
+      "start": 665.52,
+      "end": 665.68,
+      "text": "Sky"
+    },
+    {
+      "start": 665.68,
+      "end": 666,
+      "text": "team."
+    },
+    {
+      "start": 666,
+      "end": 666.16,
+      "text": "He's"
+    },
+    {
+      "start": 666.16,
+      "end": 666.32,
+      "text": "a"
+    },
+    {
+      "start": 666.33,
+      "end": 666.57,
+      "text": "protocol"
+    },
+    {
+      "start": 666.57,
+      "end": 666.97,
+      "text": "engineer"
+    },
+    {
+      "start": 666.97,
+      "end": 667.13,
+      "text": "on"
+    },
+    {
+      "start": 667.13,
+      "end": 667.21,
+      "text": "the"
+    },
+    {
+      "start": 667.21,
+      "end": 667.37,
+      "text": "Blue"
+    },
+    {
+      "start": 667.37,
+      "end": 667.61,
+      "text": "Sky"
+    },
+    {
+      "start": 667.61,
+      "end": 667.77,
+      "text": "team."
+    },
+    {
+      "start": 668.54,
+      "end": 668.86,
+      "text": "He's"
+    },
+    {
+      "start": 668.86,
+      "end": 669.02,
+      "text": "the"
+    },
+    {
+      "start": 669.02,
+      "end": 669.26,
+      "text": "best"
+    },
+    {
+      "start": 669.26,
+      "end": 669.5,
+      "text": "person"
+    },
+    {
+      "start": 669.5,
+      "end": 669.74,
+      "text": "from"
+    },
+    {
+      "start": 669.74,
+      "end": 669.82,
+      "text": "the"
+    },
+    {
+      "start": 669.82,
+      "end": 670.22,
+      "text": "PLC"
+    },
+    {
+      "start": 670.22,
+      "end": 670.54,
+      "text": "or"
+    },
+    {
+      "start": 670.54,
+      "end": 670.78,
+      "text": "from"
+    },
+    {
+      "start": 670.78,
+      "end": 670.86,
+      "text": "the"
+    },
+    {
+      "start": 670.86,
+      "end": 671.1,
+      "text": "Blue"
+    },
+    {
+      "start": 671.1,
+      "end": 671.34,
+      "text": "Sky"
+    },
+    {
+      "start": 671.34,
+      "end": 671.9,
+      "text": "team"
+    },
+    {
+      "start": 672.22,
+      "end": 672.62,
+      "text": "for"
+    },
+    {
+      "start": 672.62,
+      "end": 673.18,
+      "text": "this."
+    },
+    {
+      "start": 673.66,
+      "end": 674.06,
+      "text": "Richard"
+    },
+    {
+      "start": 674.06,
+      "end": 674.86,
+      "text": "Barnes,"
+    },
+    {
+      "start": 675.02,
+      "end": 675.18,
+      "text": "he's"
+    },
+    {
+      "start": 675.18,
+      "end": 675.34,
+      "text": "the"
+    },
+    {
+      "start": 675.34,
+      "end": 675.5,
+      "text": "co"
+    },
+    {
+      "start": 675.5,
+      "end": 675.66,
+      "text": "founder"
+    },
+    {
+      "start": 675.66,
+      "end": 675.82,
+      "text": "of"
+    },
+    {
+      "start": 675.82,
+      "end": 676.06,
+      "text": "Let's"
+    },
+    {
+      "start": 676.06,
+      "end": 676.54,
+      "text": "Encrypt,"
+    },
+    {
+      "start": 676.54,
+      "end": 676.62,
+      "text": "which"
+    },
+    {
+      "start": 676.62,
+      "end": 677.1,
+      "text": "has"
+    },
+    {
+      "start": 677.82,
+      "end": 678.14,
+      "text": "some"
+    },
+    {
+      "start": 678.14,
+      "end": 678.78,
+      "text": "analogies"
+    },
+    {
+      "start": 678.78,
+      "end": 679.18,
+      "text": "to"
+    },
+    {
+      "start": 679.18,
+      "end": 679.82,
+      "text": "PLC."
+    },
+    {
+      "start": 679.82,
+      "end": 679.9,
+      "text": "It"
+    },
+    {
+      "start": 679.9,
+      "end": 680.06,
+      "text": "looks"
+    },
+    {
+      "start": 680.06,
+      "end": 680.3,
+      "text": "pretty"
+    },
+    {
+      "start": 680.3,
+      "end": 680.62,
+      "text": "similar"
+    },
+    {
+      "start": 680.62,
+      "end": 680.7,
+      "text": "to"
+    },
+    {
+      "start": 680.7,
+      "end": 681.1,
+      "text": "PLC."
+    },
+    {
+      "start": 681.32,
+      "end": 681.64,
+      "text": "He's"
+    },
+    {
+      "start": 681.63,
+      "end": 681.79,
+      "text": "also"
+    },
+    {
+      "start": 681.79,
+      "end": 681.95,
+      "text": "the"
+    },
+    {
+      "start": 681.96,
+      "end": 682.2,
+      "text": "co"
+    },
+    {
+      "start": 682.2,
+      "end": 682.44,
+      "text": "author"
+    },
+    {
+      "start": 682.43,
+      "end": 682.59,
+      "text": "of"
+    },
+    {
+      "start": 682.6,
+      "end": 682.68,
+      "text": "the"
+    },
+    {
+      "start": 682.67,
+      "end": 683.31,
+      "text": "MLS,"
+    },
+    {
+      "start": 683.32,
+      "end": 683.8,
+      "text": "ACME,"
+    },
+    {
+      "start": 683.79,
+      "end": 684.75,
+      "text": "HPKE,"
+    },
+    {
+      "start": 684.75,
+      "end": 684.91,
+      "text": "all"
+    },
+    {
+      "start": 684.91,
+      "end": 685.23,
+      "text": "these"
+    },
+    {
+      "start": 685.24,
+      "end": 685.64,
+      "text": "deep"
+    },
+    {
+      "start": 685.63,
+      "end": 686.03,
+      "text": "crypto"
+    },
+    {
+      "start": 686.03,
+      "end": 686.75,
+      "text": "IETF"
+    },
+    {
+      "start": 686.75,
+      "end": 687.63,
+      "text": "specifications."
+    },
+    {
+      "start": 688.43,
+      "end": 688.75,
+      "text": "Wendy"
+    },
+    {
+      "start": 688.75,
+      "end": 689.39,
+      "text": "Seltzer,"
+    },
+    {
+      "start": 689.39,
+      "end": 689.55,
+      "text": "who's"
+    },
+    {
+      "start": 689.55,
+      "end": 689.63,
+      "text": "an"
+    },
+    {
+      "start": 689.63,
+      "end": 689.95,
+      "text": "internet"
+    },
+    {
+      "start": 689.96,
+      "end": 690.28,
+      "text": "lawyer"
+    },
+    {
+      "start": 690.27,
+      "end": 690.43,
+      "text": "and"
+    },
+    {
+      "start": 690.43,
+      "end": 690.67,
+      "text": "open"
+    },
+    {
+      "start": 690.67,
+      "end": 691.07,
+      "text": "standards"
+    },
+    {
+      "start": 691.08,
+      "end": 691.8,
+      "text": "advocate."
+    },
+    {
+      "start": 691.79,
+      "end": 692.03,
+      "text": "She's"
+    },
+    {
+      "start": 692.03,
+      "end": 692.19,
+      "text": "here"
+    },
+    {
+      "start": 692.2,
+      "end": 692.28,
+      "text": "at"
+    },
+    {
+      "start": 692.27,
+      "end": 692.43,
+      "text": "the"
+    },
+    {
+      "start": 692.43,
+      "end": 692.83,
+      "text": "conference."
+    },
+    {
+      "start": 692.84,
+      "end": 693,
+      "text": "You"
+    },
+    {
+      "start": 693,
+      "end": 693.24,
+      "text": "should"
+    },
+    {
+      "start": 693.24,
+      "end": 693.56,
+      "text": "find"
+    },
+    {
+      "start": 693.55,
+      "end": 694.11,
+      "text": "her"
+    },
+    {
+      "start": 694.43,
+      "end": 694.75,
+      "text": "and"
+    },
+    {
+      "start": 694.75,
+      "end": 695.15,
+      "text": "talk"
+    },
+    {
+      "start": 695.15,
+      "end": 695.23,
+      "text": "to"
+    },
+    {
+      "start": 695.24,
+      "end": 695.4,
+      "text": "her"
+    },
+    {
+      "start": 695.39,
+      "end": 695.55,
+      "text": "if"
+    },
+    {
+      "start": 695.55,
+      "end": 695.71,
+      "text": "you're"
+    },
+    {
+      "start": 695.72,
+      "end": 695.96,
+      "text": "interested."
+    },
+    {
+      "start": 699.31,
+      "end": 699.79,
+      "text": "Filippo"
+    },
+    {
+      "start": 699.79,
+      "end": 700.51,
+      "text": "Valsorta,"
+    },
+    {
+      "start": 700.51,
+      "end": 700.67,
+      "text": "who's"
+    },
+    {
+      "start": 700.67,
+      "end": 700.75,
+      "text": "a"
+    },
+    {
+      "start": 700.75,
+      "end": 701.87,
+      "text": "cryptographer."
+    },
+    {
+      "start": 702.19,
+      "end": 702.43,
+      "text": "He"
+    },
+    {
+      "start": 702.43,
+      "end": 702.83,
+      "text": "maintains"
+    },
+    {
+      "start": 702.83,
+      "end": 702.99,
+      "text": "the"
+    },
+    {
+      "start": 702.99,
+      "end": 703.23,
+      "text": "Go"
+    },
+    {
+      "start": 703.23,
+      "end": 703.79,
+      "text": "Cryptography"
+    },
+    {
+      "start": 703.79,
+      "end": 704.35,
+      "text": "library"
+    },
+    {
+      "start": 704.35,
+      "end": 704.67,
+      "text": "and"
+    },
+    {
+      "start": 704.67,
+      "end": 704.91,
+      "text": "he's"
+    },
+    {
+      "start": 704.91,
+      "end": 705.07,
+      "text": "also"
+    },
+    {
+      "start": 705.07,
+      "end": 705.23,
+      "text": "a"
+    },
+    {
+      "start": 705.23,
+      "end": 705.71,
+      "text": "transparency"
+    },
+    {
+      "start": 705.71,
+      "end": 706.03,
+      "text": "log"
+    },
+    {
+      "start": 706.03,
+      "end": 706.75,
+      "text": "aficionado"
+    },
+    {
+      "start": 706.75,
+      "end": 706.91,
+      "text": "and"
+    },
+    {
+      "start": 706.91,
+      "end": 707.07,
+      "text": "is"
+    },
+    {
+      "start": 707.07,
+      "end": 707.23,
+      "text": "working"
+    },
+    {
+      "start": 707.23,
+      "end": 707.39,
+      "text": "on"
+    },
+    {
+      "start": 707.39,
+      "end": 707.55,
+      "text": "the"
+    },
+    {
+      "start": 707.55,
+      "end": 707.79,
+      "text": "project"
+    },
+    {
+      "start": 707.79,
+      "end": 708.27,
+      "text": "Sunlight"
+    },
+    {
+      "start": 708.27,
+      "end": 708.83,
+      "text": "implementation."
+    },
+    {
+      "start": 709.13,
+      "end": 709.37,
+      "text": "He"
+    },
+    {
+      "start": 709.37,
+      "end": 709.61,
+      "text": "is"
+    },
+    {
+      "start": 709.61,
+      "end": 709.93,
+      "text": "also"
+    },
+    {
+      "start": 709.92,
+      "end": 710.16,
+      "text": "here"
+    },
+    {
+      "start": 710.16,
+      "end": 710.32,
+      "text": "at"
+    },
+    {
+      "start": 710.33,
+      "end": 710.41,
+      "text": "the"
+    },
+    {
+      "start": 710.4,
+      "end": 710.8,
+      "text": "conference."
+    },
+    {
+      "start": 710.8,
+      "end": 710.96,
+      "text": "You"
+    },
+    {
+      "start": 710.97,
+      "end": 711.13,
+      "text": "should"
+    },
+    {
+      "start": 711.13,
+      "end": 711.29,
+      "text": "come"
+    },
+    {
+      "start": 711.28,
+      "end": 711.44,
+      "text": "talk"
+    },
+    {
+      "start": 711.45,
+      "end": 711.61,
+      "text": "to"
+    },
+    {
+      "start": 711.61,
+      "end": 712.17,
+      "text": "him."
+    },
+    {
+      "start": 714.64,
+      "end": 714.8,
+      "text": "And"
+    },
+    {
+      "start": 714.8,
+      "end": 715.12,
+      "text": "then,"
+    },
+    {
+      "start": 715.13,
+      "end": 715.77,
+      "text": "Tyla,"
+    },
+    {
+      "start": 715.76,
+      "end": 715.92,
+      "text": "and"
+    },
+    {
+      "start": 715.92,
+      "end": 716.16,
+      "text": "I"
+    },
+    {
+      "start": 716.16,
+      "end": 716.32,
+      "text": "don't"
+    },
+    {
+      "start": 716.33,
+      "end": 716.41,
+      "text": "know"
+    },
+    {
+      "start": 716.4,
+      "end": 716.56,
+      "text": "how"
+    },
+    {
+      "start": 716.57,
+      "end": 716.65,
+      "text": "to"
+    },
+    {
+      "start": 716.64,
+      "end": 716.88,
+      "text": "pronounce"
+    },
+    {
+      "start": 716.88,
+      "end": 716.96,
+      "text": "her"
+    },
+    {
+      "start": 716.97,
+      "end": 717.29,
+      "text": "last"
+    },
+    {
+      "start": 717.28,
+      "end": 717.44,
+      "text": "name"
+    },
+    {
+      "start": 717.45,
+      "end": 718.01,
+      "text": "unfortunately,"
+    },
+    {
+      "start": 718,
+      "end": 718.08,
+      "text": "but"
+    },
+    {
+      "start": 718.09,
+      "end": 718.33,
+      "text": "she's"
+    },
+    {
+      "start": 718.33,
+      "end": 718.41,
+      "text": "a"
+    },
+    {
+      "start": 718.4,
+      "end": 719.04,
+      "text": "cryptographer"
+    },
+    {
+      "start": 719.04,
+      "end": 719.2,
+      "text": "and"
+    },
+    {
+      "start": 719.21,
+      "end": 719.45,
+      "text": "a"
+    },
+    {
+      "start": 719.45,
+      "end": 719.85,
+      "text": "security"
+    },
+    {
+      "start": 719.85,
+      "end": 720.01,
+      "text": "and"
+    },
+    {
+      "start": 720,
+      "end": 720.4,
+      "text": "privacy"
+    },
+    {
+      "start": 720.4,
+      "end": 721.12,
+      "text": "engineer"
+    },
+    {
+      "start": 721.13,
+      "end": 721.37,
+      "text": "at"
+    },
+    {
+      "start": 721.37,
+      "end": 722.01,
+      "text": "Google."
+    },
+    {
+      "start": 722.25,
+      "end": 722.49,
+      "text": "She"
+    },
+    {
+      "start": 722.42,
+      "end": 722.74,
+      "text": "also"
+    },
+    {
+      "start": 722.74,
+      "end": 722.98,
+      "text": "lives"
+    },
+    {
+      "start": 722.98,
+      "end": 723.14,
+      "text": "in"
+    },
+    {
+      "start": 723.14,
+      "end": 723.86,
+      "text": "Switzerland,"
+    },
+    {
+      "start": 723.86,
+      "end": 724.02,
+      "text": "is"
+    },
+    {
+      "start": 724.02,
+      "end": 724.34,
+      "text": "quite"
+    },
+    {
+      "start": 724.34,
+      "end": 724.58,
+      "text": "nice"
+    },
+    {
+      "start": 724.58,
+      "end": 724.98,
+      "text": "for"
+    },
+    {
+      "start": 724.98,
+      "end": 725.7,
+      "text": "organizational"
+    },
+    {
+      "start": 725.7,
+      "end": 726.5,
+      "text": "reasons."
+    },
+    {
+      "start": 729.14,
+      "end": 729.54,
+      "text": "Yeah."
+    },
+    {
+      "start": 729.54,
+      "end": 729.7,
+      "text": "So"
+    },
+    {
+      "start": 729.7,
+      "end": 729.94,
+      "text": "just"
+    },
+    {
+      "start": 729.94,
+      "end": 730.18,
+      "text": "to"
+    },
+    {
+      "start": 730.18,
+      "end": 730.42,
+      "text": "just"
+    },
+    {
+      "start": 730.42,
+      "end": 730.58,
+      "text": "to"
+    },
+    {
+      "start": 730.58,
+      "end": 730.74,
+      "text": "note"
+    },
+    {
+      "start": 730.74,
+      "end": 731.14,
+      "text": "again,"
+    },
+    {
+      "start": 731.14,
+      "end": 731.3,
+      "text": "this"
+    },
+    {
+      "start": 731.3,
+      "end": 731.46,
+      "text": "is"
+    },
+    {
+      "start": 731.46,
+      "end": 731.62,
+      "text": "like"
+    },
+    {
+      "start": 731.62,
+      "end": 731.78,
+      "text": "the"
+    },
+    {
+      "start": 731.78,
+      "end": 732.02,
+      "text": "first"
+    },
+    {
+      "start": 732.02,
+      "end": 732.58,
+      "text": "step"
+    },
+    {
+      "start": 732.82,
+      "end": 733.14,
+      "text": "in"
+    },
+    {
+      "start": 733.14,
+      "end": 733.3,
+      "text": "the"
+    },
+    {
+      "start": 733.3,
+      "end": 733.78,
+      "text": "evolution"
+    },
+    {
+      "start": 733.78,
+      "end": 733.94,
+      "text": "of"
+    },
+    {
+      "start": 733.94,
+      "end": 734.5,
+      "text": "PLC."
+    },
+    {
+      "start": 734.5,
+      "end": 734.58,
+      "text": "This"
+    },
+    {
+      "start": 734.58,
+      "end": 734.82,
+      "text": "isn't"
+    },
+    {
+      "start": 734.82,
+      "end": 734.98,
+      "text": "the"
+    },
+    {
+      "start": 734.98,
+      "end": 735.14,
+      "text": "end"
+    },
+    {
+      "start": 735.14,
+      "end": 735.3,
+      "text": "state"
+    },
+    {
+      "start": 735.3,
+      "end": 735.46,
+      "text": "of"
+    },
+    {
+      "start": 735.46,
+      "end": 735.62,
+      "text": "it."
+    },
+    {
+      "start": 735.62,
+      "end": 735.78,
+      "text": "We're"
+    },
+    {
+      "start": 735.78,
+      "end": 735.94,
+      "text": "going"
+    },
+    {
+      "start": 735.94,
+      "end": 736.02,
+      "text": "to"
+    },
+    {
+      "start": 736.02,
+      "end": 736.42,
+      "text": "continue"
+    },
+    {
+      "start": 736.42,
+      "end": 736.74,
+      "text": "working"
+    },
+    {
+      "start": 736.74,
+      "end": 736.9,
+      "text": "on"
+    },
+    {
+      "start": 736.9,
+      "end": 737.06,
+      "text": "this."
+    },
+    {
+      "start": 737.77,
+      "end": 738.09,
+      "text": "We"
+    },
+    {
+      "start": 738.1,
+      "end": 738.34,
+      "text": "also"
+    },
+    {
+      "start": 738.33,
+      "end": 738.73,
+      "text": "haven't"
+    },
+    {
+      "start": 738.74,
+      "end": 739.06,
+      "text": "actually"
+    },
+    {
+      "start": 739.05,
+      "end": 739.45,
+      "text": "transferred"
+    },
+    {
+      "start": 739.45,
+      "end": 739.77,
+      "text": "any"
+    },
+    {
+      "start": 739.77,
+      "end": 740.01,
+      "text": "assets"
+    },
+    {
+      "start": 740.01,
+      "end": 740.25,
+      "text": "over"
+    },
+    {
+      "start": 740.25,
+      "end": 740.41,
+      "text": "to"
+    },
+    {
+      "start": 740.41,
+      "end": 741.13,
+      "text": "PLC."
+    },
+    {
+      "start": 741.29,
+      "end": 741.53,
+      "text": "That"
+    },
+    {
+      "start": 741.53,
+      "end": 741.69,
+      "text": "is"
+    },
+    {
+      "start": 741.7,
+      "end": 741.94,
+      "text": "something"
+    },
+    {
+      "start": 741.93,
+      "end": 742.09,
+      "text": "that"
+    },
+    {
+      "start": 742.1,
+      "end": 742.34,
+      "text": "we'll"
+    },
+    {
+      "start": 742.33,
+      "end": 742.49,
+      "text": "be"
+    },
+    {
+      "start": 742.5,
+      "end": 742.66,
+      "text": "doing"
+    },
+    {
+      "start": 742.65,
+      "end": 742.81,
+      "text": "in"
+    },
+    {
+      "start": 742.82,
+      "end": 742.9,
+      "text": "the"
+    },
+    {
+      "start": 742.89,
+      "end": 743.05,
+      "text": "coming"
+    },
+    {
+      "start": 743.05,
+      "end": 743.29,
+      "text": "months"
+    },
+    {
+      "start": 743.29,
+      "end": 743.45,
+      "text": "and"
+    },
+    {
+      "start": 743.45,
+      "end": 743.61,
+      "text": "we'll"
+    },
+    {
+      "start": 743.62,
+      "end": 743.78,
+      "text": "give"
+    },
+    {
+      "start": 743.77,
+      "end": 744.01,
+      "text": "updates"
+    },
+    {
+      "start": 744.01,
+      "end": 744.25,
+      "text": "as"
+    },
+    {
+      "start": 744.25,
+      "end": 744.41,
+      "text": "that"
+    },
+    {
+      "start": 744.41,
+      "end": 744.81,
+      "text": "happens."
+    },
+    {
+      "start": 744.82,
+      "end": 744.9,
+      "text": "The"
+    },
+    {
+      "start": 744.89,
+      "end": 745.05,
+      "text": "first"
+    },
+    {
+      "start": 745.05,
+      "end": 745.29,
+      "text": "order"
+    },
+    {
+      "start": 745.29,
+      "end": 745.45,
+      "text": "of"
+    },
+    {
+      "start": 745.45,
+      "end": 745.69,
+      "text": "business"
+    },
+    {
+      "start": 745.7,
+      "end": 745.94,
+      "text": "is"
+    },
+    {
+      "start": 745.93,
+      "end": 746.17,
+      "text": "getting"
+    },
+    {
+      "start": 746.17,
+      "end": 746.33,
+      "text": "the"
+    },
+    {
+      "start": 746.33,
+      "end": 746.73,
+      "text": "domain"
+    },
+    {
+      "start": 746.74,
+      "end": 747.06,
+      "text": "name"
+    },
+    {
+      "start": 747.05,
+      "end": 747.37,
+      "text": "over"
+    },
+    {
+      "start": 747.38,
+      "end": 747.62,
+      "text": "to"
+    },
+    {
+      "start": 747.62,
+      "end": 748.26,
+      "text": "PLC."
+    },
+    {
+      "start": 750.52,
+      "end": 751,
+      "text": "Alongside"
+    },
+    {
+      "start": 751,
+      "end": 751.32,
+      "text": "these"
+    },
+    {
+      "start": 751.32,
+      "end": 751.88,
+      "text": "organizational"
+    },
+    {
+      "start": 751.88,
+      "end": 752.36,
+      "text": "improvements,"
+    },
+    {
+      "start": 752.36,
+      "end": 752.44,
+      "text": "we"
+    },
+    {
+      "start": 752.44,
+      "end": 752.6,
+      "text": "also"
+    },
+    {
+      "start": 752.6,
+      "end": 752.76,
+      "text": "have"
+    },
+    {
+      "start": 752.76,
+      "end": 753,
+      "text": "some"
+    },
+    {
+      "start": 753,
+      "end": 753.4,
+      "text": "technical"
+    },
+    {
+      "start": 753.4,
+      "end": 753.72,
+      "text": "improvements"
+    },
+    {
+      "start": 753.72,
+      "end": 753.96,
+      "text": "to"
+    },
+    {
+      "start": 753.96,
+      "end": 754.52,
+      "text": "PLC."
+    },
+    {
+      "start": 754.52,
+      "end": 754.68,
+      "text": "We"
+    },
+    {
+      "start": 754.68,
+      "end": 754.92,
+      "text": "shipped"
+    },
+    {
+      "start": 754.92,
+      "end": 755.24,
+      "text": "streaming"
+    },
+    {
+      "start": 755.24,
+      "end": 755.8,
+      "text": "replication"
+    },
+    {
+      "start": 755.8,
+      "end": 756.12,
+      "text": "and"
+    },
+    {
+      "start": 756.12,
+      "end": 756.28,
+      "text": "a"
+    },
+    {
+      "start": 756.28,
+      "end": 756.76,
+      "text": "replica"
+    },
+    {
+      "start": 756.76,
+      "end": 757.24,
+      "text": "reference"
+    },
+    {
+      "start": 757.24,
+      "end": 758.2,
+      "text": "implementation"
+    },
+    {
+      "start": 758.36,
+      "end": 758.68,
+      "text": "that"
+    },
+    {
+      "start": 758.68,
+      "end": 759.08,
+      "text": "provides"
+    },
+    {
+      "start": 759.08,
+      "end": 759.4,
+      "text": "full"
+    },
+    {
+      "start": 759.4,
+      "end": 760.12,
+      "text": "verification"
+    },
+    {
+      "start": 760.12,
+      "end": 760.36,
+      "text": "of"
+    },
+    {
+      "start": 760.36,
+      "end": 760.52,
+      "text": "all"
+    },
+    {
+      "start": 760.52,
+      "end": 761.08,
+      "text": "directory"
+    },
+    {
+      "start": 761.08,
+      "end": 762.04,
+      "text": "operations."
+    },
+    {
+      "start": 762.12,
+      "end": 762.52,
+      "text": "There's"
+    },
+    {
+      "start": 762.52,
+      "end": 762.68,
+      "text": "a"
+    },
+    {
+      "start": 762.68,
+      "end": 762.84,
+      "text": "number"
+    },
+    {
+      "start": 762.84,
+      "end": 763,
+      "text": "of"
+    },
+    {
+      "start": 763,
+      "end": 763.16,
+      "text": "people"
+    },
+    {
+      "start": 763.16,
+      "end": 763.32,
+      "text": "that"
+    },
+    {
+      "start": 763.32,
+      "end": 763.4,
+      "text": "are"
+    },
+    {
+      "start": 763.4,
+      "end": 763.64,
+      "text": "running"
+    },
+    {
+      "start": 763.64,
+      "end": 763.88,
+      "text": "this"
+    },
+    {
+      "start": 763.88,
+      "end": 763.96,
+      "text": "in"
+    },
+    {
+      "start": 763.96,
+      "end": 764.12,
+      "text": "the"
+    },
+    {
+      "start": 764.12,
+      "end": 764.44,
+      "text": "network"
+    },
+    {
+      "start": 764.44,
+      "end": 764.76,
+      "text": "already."
+    },
+    {
+      "start": 764.99,
+      "end": 765.31,
+      "text": "And"
+    },
+    {
+      "start": 765.3,
+      "end": 765.46,
+      "text": "the"
+    },
+    {
+      "start": 765.46,
+      "end": 765.7,
+      "text": "longer"
+    },
+    {
+      "start": 765.7,
+      "end": 765.94,
+      "text": "term"
+    },
+    {
+      "start": 765.95,
+      "end": 766.27,
+      "text": "plan"
+    },
+    {
+      "start": 766.26,
+      "end": 766.5,
+      "text": "is"
+    },
+    {
+      "start": 766.5,
+      "end": 766.66,
+      "text": "a"
+    },
+    {
+      "start": 766.66,
+      "end": 767.22,
+      "text": "sophistication"
+    },
+    {
+      "start": 767.23,
+      "end": 767.39,
+      "text": "of"
+    },
+    {
+      "start": 767.38,
+      "end": 767.7,
+      "text": "that,"
+    },
+    {
+      "start": 767.7,
+      "end": 767.78,
+      "text": "which"
+    },
+    {
+      "start": 767.78,
+      "end": 767.94,
+      "text": "is"
+    },
+    {
+      "start": 767.95,
+      "end": 768.51,
+      "text": "transparency"
+    },
+    {
+      "start": 768.5,
+      "end": 769.22,
+      "text": "logs."
+    },
+    {
+      "start": 769.23,
+      "end": 769.31,
+      "text": "And"
+    },
+    {
+      "start": 769.3,
+      "end": 769.46,
+      "text": "you"
+    },
+    {
+      "start": 769.46,
+      "end": 769.54,
+      "text": "know"
+    },
+    {
+      "start": 769.54,
+      "end": 769.7,
+      "text": "that"
+    },
+    {
+      "start": 769.7,
+      "end": 769.86,
+      "text": "we're"
+    },
+    {
+      "start": 769.87,
+      "end": 770.03,
+      "text": "gonna"
+    },
+    {
+      "start": 770.02,
+      "end": 770.1,
+      "text": "do"
+    },
+    {
+      "start": 770.11,
+      "end": 770.27,
+      "text": "that"
+    },
+    {
+      "start": 770.26,
+      "end": 770.5,
+      "text": "because"
+    },
+    {
+      "start": 770.5,
+      "end": 770.58,
+      "text": "we"
+    },
+    {
+      "start": 770.58,
+      "end": 770.74,
+      "text": "have"
+    },
+    {
+      "start": 770.75,
+      "end": 771.15,
+      "text": "Filipo"
+    },
+    {
+      "start": 771.14,
+      "end": 771.38,
+      "text": "on"
+    },
+    {
+      "start": 771.38,
+      "end": 771.54,
+      "text": "the"
+    },
+    {
+      "start": 771.54,
+      "end": 772.1,
+      "text": "board."
+    },
+    {
+      "start": 775.7,
+      "end": 776.5,
+      "text": "Great."
+    },
+    {
+      "start": 776.66,
+      "end": 777.38,
+      "text": "Now"
+    },
+    {
+      "start": 777.65,
+      "end": 778.05,
+      "text": "So,"
+    },
+    {
+      "start": 778.05,
+      "end": 778.21,
+      "text": "those"
+    },
+    {
+      "start": 778.21,
+      "end": 778.37,
+      "text": "are"
+    },
+    {
+      "start": 778.37,
+      "end": 778.53,
+      "text": "sort"
+    },
+    {
+      "start": 778.53,
+      "end": 778.61,
+      "text": "of"
+    },
+    {
+      "start": 778.61,
+      "end": 778.77,
+      "text": "like"
+    },
+    {
+      "start": 778.77,
+      "end": 778.93,
+      "text": "the"
+    },
+    {
+      "start": 778.93,
+      "end": 779.49,
+      "text": "governance"
+    },
+    {
+      "start": 779.49,
+      "end": 779.97,
+      "text": "updates"
+    },
+    {
+      "start": 779.97,
+      "end": 780.29,
+      "text": "on"
+    },
+    {
+      "start": 780.29,
+      "end": 780.45,
+      "text": "like"
+    },
+    {
+      "start": 780.45,
+      "end": 780.61,
+      "text": "kind"
+    },
+    {
+      "start": 780.61,
+      "end": 780.77,
+      "text": "of"
+    },
+    {
+      "start": 780.77,
+      "end": 780.93,
+      "text": "these"
+    },
+    {
+      "start": 780.93,
+      "end": 781.17,
+      "text": "core"
+    },
+    {
+      "start": 781.17,
+      "end": 781.49,
+      "text": "parts"
+    },
+    {
+      "start": 781.49,
+      "end": 781.65,
+      "text": "of"
+    },
+    {
+      "start": 781.65,
+      "end": 781.73,
+      "text": "the"
+    },
+    {
+      "start": 781.73,
+      "end": 782.45,
+      "text": "protocol."
+    },
+    {
+      "start": 782.45,
+      "end": 782.69,
+      "text": "This"
+    },
+    {
+      "start": 782.69,
+      "end": 782.85,
+      "text": "next"
+    },
+    {
+      "start": 782.85,
+      "end": 783.09,
+      "text": "section"
+    },
+    {
+      "start": 783.09,
+      "end": 783.33,
+      "text": "is"
+    },
+    {
+      "start": 783.33,
+      "end": 783.49,
+      "text": "about"
+    },
+    {
+      "start": 783.49,
+      "end": 783.89,
+      "text": "hard"
+    },
+    {
+      "start": 783.89,
+      "end": 784.85,
+      "text": "decentralization"
+    },
+    {
+      "start": 784.85,
+      "end": 785.41,
+      "text": "or"
+    },
+    {
+      "start": 785.41,
+      "end": 785.81,
+      "text": "that's"
+    },
+    {
+      "start": 785.81,
+      "end": 785.97,
+      "text": "great"
+    },
+    {
+      "start": 785.97,
+      "end": 786.13,
+      "text": "and"
+    },
+    {
+      "start": 786.13,
+      "end": 786.29,
+      "text": "all,"
+    },
+    {
+      "start": 786.29,
+      "end": 786.45,
+      "text": "but"
+    },
+    {
+      "start": 786.45,
+      "end": 786.61,
+      "text": "what"
+    },
+    {
+      "start": 786.61,
+      "end": 786.77,
+      "text": "happens"
+    },
+    {
+      "start": 786.77,
+      "end": 787.01,
+      "text": "when"
+    },
+    {
+      "start": 787.01,
+      "end": 787.25,
+      "text": "blue"
+    },
+    {
+      "start": 787.25,
+      "end": 787.49,
+      "text": "sky"
+    },
+    {
+      "start": 787.49,
+      "end": 787.73,
+      "text": "kills"
+    },
+    {
+      "start": 787.73,
+      "end": 788.05,
+      "text": "API"
+    },
+    {
+      "start": 788.05,
+      "end": 788.85,
+      "text": "access"
+    },
+    {
+      "start": 788.93,
+      "end": 789.25,
+      "text": "or"
+    },
+    {
+      "start": 789.25,
+      "end": 789.81,
+      "text": "servers"
+    },
+    {
+      "start": 789.81,
+      "end": 790.05,
+      "text": "are"
+    },
+    {
+      "start": 790.05,
+      "end": 790.29,
+      "text": "actually"
+    },
+    {
+      "start": 790.29,
+      "end": 790.53,
+      "text": "just"
+    },
+    {
+      "start": 790.53,
+      "end": 790.93,
+      "text": "physical"
+    },
+    {
+      "start": 790.93,
+      "end": 791.17,
+      "text": "objects"
+    },
+    {
+      "start": 791.17,
+      "end": 791.41,
+      "text": "that"
+    },
+    {
+      "start": 791.41,
+      "end": 791.57,
+      "text": "can"
+    },
+    {
+      "start": 791.57,
+      "end": 791.65,
+      "text": "be"
+    },
+    {
+      "start": 791.65,
+      "end": 792.21,
+      "text": "destroyed,"
+    },
+    {
+      "start": 792.21,
+      "end": 792.85,
+      "text": "unplugged,"
+    },
+    {
+      "start": 792.85,
+      "end": 792.93,
+      "text": "or"
+    },
+    {
+      "start": 792.93,
+      "end": 793.33,
+      "text": "seized."
+    },
+    {
+      "start": 793.42,
+      "end": 793.74,
+      "text": "This"
+    },
+    {
+      "start": 793.74,
+      "end": 793.9,
+      "text": "is"
+    },
+    {
+      "start": 793.89,
+      "end": 794.05,
+      "text": "kind"
+    },
+    {
+      "start": 794.05,
+      "end": 794.13,
+      "text": "of"
+    },
+    {
+      "start": 794.13,
+      "end": 794.29,
+      "text": "the"
+    },
+    {
+      "start": 794.3,
+      "end": 794.54,
+      "text": "real"
+    },
+    {
+      "start": 794.54,
+      "end": 794.94,
+      "text": "politic"
+    },
+    {
+      "start": 794.93,
+      "end": 795.09,
+      "text": "of"
+    },
+    {
+      "start": 795.1,
+      "end": 795.34,
+      "text": "running"
+    },
+    {
+      "start": 795.34,
+      "end": 795.42,
+      "text": "a"
+    },
+    {
+      "start": 795.42,
+      "end": 795.66,
+      "text": "multi"
+    },
+    {
+      "start": 795.65,
+      "end": 796.05,
+      "text": "stakeholder"
+    },
+    {
+      "start": 796.05,
+      "end": 796.77,
+      "text": "network,"
+    },
+    {
+      "start": 796.77,
+      "end": 796.93,
+      "text": "where"
+    },
+    {
+      "start": 796.93,
+      "end": 797.01,
+      "text": "you"
+    },
+    {
+      "start": 797.01,
+      "end": 797.17,
+      "text": "have"
+    },
+    {
+      "start": 797.18,
+      "end": 797.5,
+      "text": "one"
+    },
+    {
+      "start": 797.5,
+      "end": 797.74,
+      "text": "big"
+    },
+    {
+      "start": 797.74,
+      "end": 798.14,
+      "text": "person"
+    },
+    {
+      "start": 798.13,
+      "end": 798.37,
+      "text": "at"
+    },
+    {
+      "start": 798.38,
+      "end": 798.54,
+      "text": "the"
+    },
+    {
+      "start": 798.54,
+      "end": 798.78,
+      "text": "center"
+    },
+    {
+      "start": 798.77,
+      "end": 798.93,
+      "text": "of"
+    },
+    {
+      "start": 798.93,
+      "end": 799.33,
+      "text": "it."
+    },
+    {
+      "start": 799.34,
+      "end": 799.58,
+      "text": "What"
+    },
+    {
+      "start": 799.58,
+      "end": 799.74,
+      "text": "are"
+    },
+    {
+      "start": 799.74,
+      "end": 799.9,
+      "text": "the"
+    },
+    {
+      "start": 799.89,
+      "end": 800.37,
+      "text": "particular"
+    },
+    {
+      "start": 800.38,
+      "end": 800.78,
+      "text": "threats"
+    },
+    {
+      "start": 800.77,
+      "end": 801.25,
+      "text": "and"
+    },
+    {
+      "start": 801.25,
+      "end": 801.57,
+      "text": "what"
+    },
+    {
+      "start": 801.58,
+      "end": 801.74,
+      "text": "can"
+    },
+    {
+      "start": 801.74,
+      "end": 801.9,
+      "text": "they"
+    },
+    {
+      "start": 801.89,
+      "end": 802.05,
+      "text": "get"
+    },
+    {
+      "start": 802.05,
+      "end": 802.29,
+      "text": "away"
+    },
+    {
+      "start": 802.3,
+      "end": 802.78,
+      "text": "with?"
+    },
+    {
+      "start": 803.25,
+      "end": 803.65,
+      "text": "So,"
+    },
+    {
+      "start": 803.65,
+      "end": 803.73,
+      "text": "I"
+    },
+    {
+      "start": 803.74,
+      "end": 803.98,
+      "text": "wanna"
+    },
+    {
+      "start": 803.98,
+      "end": 804.14,
+      "text": "call"
+    },
+    {
+      "start": 804.13,
+      "end": 804.29,
+      "text": "out"
+    },
+    {
+      "start": 804.3,
+      "end": 804.46,
+      "text": "that"
+    },
+    {
+      "start": 804.46,
+      "end": 805.34,
+      "text": "decentralization"
+    },
+    {
+      "start": 805.34,
+      "end": 805.74,
+      "text": "isn't"
+    },
+    {
+      "start": 805.74,
+      "end": 805.98,
+      "text": "just"
+    },
+    {
+      "start": 805.98,
+      "end": 806.3,
+      "text": "one"
+    },
+    {
+      "start": 806.3,
+      "end": 806.54,
+      "text": "thing"
+    },
+    {
+      "start": 806.54,
+      "end": 806.94,
+      "text": "and"
+    },
+    {
+      "start": 806.93,
+      "end": 807.09,
+      "text": "we"
+    },
+    {
+      "start": 807.1,
+      "end": 807.26,
+      "text": "need"
+    },
+    {
+      "start": 807.25,
+      "end": 807.33,
+      "text": "to"
+    },
+    {
+      "start": 807.34,
+      "end": 807.5,
+      "text": "think"
+    },
+    {
+      "start": 807.5,
+      "end": 807.74,
+      "text": "through"
+    },
+    {
+      "start": 807.74,
+      "end": 807.98,
+      "text": "what"
+    },
+    {
+      "start": 807.98,
+      "end": 808.14,
+      "text": "those"
+    },
+    {
+      "start": 808.13,
+      "end": 808.45,
+      "text": "threats"
+    },
+    {
+      "start": 808.46,
+      "end": 809.18,
+      "text": "actually"
+    },
+    {
+      "start": 808.74,
+      "end": 808.82,
+      "text": "actually"
+    },
+    {
+      "start": 808.82,
+      "end": 809.14,
+      "text": "are."
+    },
+    {
+      "start": 809.14,
+      "end": 810.9,
+      "text": "Numbers"
+    },
+    {
+      "start": 810.9,
+      "end": 811.14,
+      "text": "are"
+    },
+    {
+      "start": 811.14,
+      "end": 811.7,
+      "text": "important,"
+    },
+    {
+      "start": 811.7,
+      "end": 811.78,
+      "text": "but"
+    },
+    {
+      "start": 811.78,
+      "end": 811.94,
+      "text": "I'm"
+    },
+    {
+      "start": 811.94,
+      "end": 812.26,
+      "text": "somewhat"
+    },
+    {
+      "start": 812.26,
+      "end": 812.9,
+      "text": "uninterested"
+    },
+    {
+      "start": 812.9,
+      "end": 813.14,
+      "text": "in"
+    },
+    {
+      "start": 813.14,
+      "end": 813.46,
+      "text": "like"
+    },
+    {
+      "start": 813.46,
+      "end": 813.7,
+      "text": "what"
+    },
+    {
+      "start": 813.7,
+      "end": 814.1,
+      "text": "percentage"
+    },
+    {
+      "start": 814.1,
+      "end": 814.34,
+      "text": "of"
+    },
+    {
+      "start": 814.34,
+      "end": 814.58,
+      "text": "people"
+    },
+    {
+      "start": 814.58,
+      "end": 814.74,
+      "text": "are"
+    },
+    {
+      "start": 814.74,
+      "end": 814.9,
+      "text": "on"
+    },
+    {
+      "start": 814.9,
+      "end": 815.14,
+      "text": "what"
+    },
+    {
+      "start": 815.14,
+      "end": 815.38,
+      "text": "thing"
+    },
+    {
+      "start": 815.38,
+      "end": 815.62,
+      "text": "or"
+    },
+    {
+      "start": 815.62,
+      "end": 815.94,
+      "text": "what."
+    },
+    {
+      "start": 815.94,
+      "end": 816.34,
+      "text": "It's"
+    },
+    {
+      "start": 816.34,
+      "end": 816.58,
+      "text": "what"
+    },
+    {
+      "start": 816.58,
+      "end": 816.74,
+      "text": "are"
+    },
+    {
+      "start": 816.74,
+      "end": 816.9,
+      "text": "the"
+    },
+    {
+      "start": 816.9,
+      "end": 817.38,
+      "text": "actual"
+    },
+    {
+      "start": 817.38,
+      "end": 817.86,
+      "text": "threats"
+    },
+    {
+      "start": 817.86,
+      "end": 818.1,
+      "text": "that"
+    },
+    {
+      "start": 818.1,
+      "end": 818.34,
+      "text": "come"
+    },
+    {
+      "start": 818.34,
+      "end": 818.58,
+      "text": "from"
+    },
+    {
+      "start": 818.58,
+      "end": 818.9,
+      "text": "Blue"
+    },
+    {
+      "start": 818.9,
+      "end": 819.14,
+      "text": "Sky"
+    },
+    {
+      "start": 819.14,
+      "end": 819.38,
+      "text": "being"
+    },
+    {
+      "start": 819.38,
+      "end": 819.86,
+      "text": "outsized"
+    },
+    {
+      "start": 819.86,
+      "end": 820.1,
+      "text": "in"
+    },
+    {
+      "start": 820.1,
+      "end": 820.34,
+      "text": "this"
+    },
+    {
+      "start": 820.34,
+      "end": 820.98,
+      "text": "ecosystem."
+    },
+    {
+      "start": 821.14,
+      "end": 821.46,
+      "text": "Let's"
+    },
+    {
+      "start": 821.46,
+      "end": 821.7,
+      "text": "think"
+    },
+    {
+      "start": 821.7,
+      "end": 821.86,
+      "text": "through"
+    },
+    {
+      "start": 821.86,
+      "end": 822.18,
+      "text": "those"
+    },
+    {
+      "start": 822.18,
+      "end": 822.42,
+      "text": "threats"
+    },
+    {
+      "start": 822.42,
+      "end": 822.66,
+      "text": "and"
+    },
+    {
+      "start": 822.66,
+      "end": 822.9,
+      "text": "think"
+    },
+    {
+      "start": 822.9,
+      "end": 823.06,
+      "text": "through"
+    },
+    {
+      "start": 823.06,
+      "end": 823.22,
+      "text": "how"
+    },
+    {
+      "start": 823.22,
+      "end": 823.46,
+      "text": "Blue"
+    },
+    {
+      "start": 823.46,
+      "end": 823.7,
+      "text": "Sky"
+    },
+    {
+      "start": 823.7,
+      "end": 823.94,
+      "text": "can"
+    },
+    {
+      "start": 823.94,
+      "end": 824.26,
+      "text": "address"
+    },
+    {
+      "start": 824.26,
+      "end": 825.06,
+      "text": "them"
+    },
+    {
+      "start": 824.57,
+      "end": 824.81,
+      "text": "and"
+    },
+    {
+      "start": 824.8,
+      "end": 825.04,
+      "text": "how"
+    },
+    {
+      "start": 825.04,
+      "end": 825.28,
+      "text": "the"
+    },
+    {
+      "start": 825.28,
+      "end": 825.68,
+      "text": "network"
+    },
+    {
+      "start": 825.68,
+      "end": 825.92,
+      "text": "can"
+    },
+    {
+      "start": 825.92,
+      "end": 826.24,
+      "text": "address"
+    },
+    {
+      "start": 826.25,
+      "end": 826.73,
+      "text": "them."
+    },
+    {
+      "start": 827.52,
+      "end": 828.16,
+      "text": "So,"
+    },
+    {
+      "start": 828.25,
+      "end": 828.49,
+      "text": "we're"
+    },
+    {
+      "start": 828.49,
+      "end": 828.65,
+      "text": "gonna"
+    },
+    {
+      "start": 828.64,
+      "end": 828.72,
+      "text": "do"
+    },
+    {
+      "start": 828.73,
+      "end": 828.97,
+      "text": "some"
+    },
+    {
+      "start": 828.97,
+      "end": 829.21,
+      "text": "threat"
+    },
+    {
+      "start": 829.21,
+      "end": 829.53,
+      "text": "modeling"
+    },
+    {
+      "start": 829.52,
+      "end": 829.76,
+      "text": "on"
+    },
+    {
+      "start": 829.76,
+      "end": 829.92,
+      "text": "what"
+    },
+    {
+      "start": 829.92,
+      "end": 830.08,
+      "text": "Blue"
+    },
+    {
+      "start": 830.09,
+      "end": 830.33,
+      "text": "Sky"
+    },
+    {
+      "start": 830.33,
+      "end": 830.49,
+      "text": "could"
+    },
+    {
+      "start": 830.49,
+      "end": 830.65,
+      "text": "do"
+    },
+    {
+      "start": 830.64,
+      "end": 830.8,
+      "text": "and"
+    },
+    {
+      "start": 830.8,
+      "end": 830.96,
+      "text": "then"
+    },
+    {
+      "start": 830.97,
+      "end": 831.13,
+      "text": "we're"
+    },
+    {
+      "start": 831.13,
+      "end": 831.29,
+      "text": "gonna"
+    },
+    {
+      "start": 831.28,
+      "end": 831.52,
+      "text": "talk"
+    },
+    {
+      "start": 831.52,
+      "end": 831.68,
+      "text": "through"
+    },
+    {
+      "start": 831.68,
+      "end": 831.84,
+      "text": "some"
+    },
+    {
+      "start": 831.85,
+      "end": 831.93,
+      "text": "of"
+    },
+    {
+      "start": 831.92,
+      "end": 832.08,
+      "text": "the"
+    },
+    {
+      "start": 832.09,
+      "end": 832.73,
+      "text": "solutions."
+    },
+    {
+      "start": 833.13,
+      "end": 833.69,
+      "text": "So,"
+    },
+    {
+      "start": 834,
+      "end": 834.16,
+      "text": "the"
+    },
+    {
+      "start": 834.16,
+      "end": 834.4,
+      "text": "most"
+    },
+    {
+      "start": 834.4,
+      "end": 834.64,
+      "text": "common"
+    },
+    {
+      "start": 834.64,
+      "end": 834.8,
+      "text": "thing"
+    },
+    {
+      "start": 834.8,
+      "end": 834.96,
+      "text": "that"
+    },
+    {
+      "start": 834.97,
+      "end": 835.21,
+      "text": "people"
+    },
+    {
+      "start": 835.21,
+      "end": 835.37,
+      "text": "think"
+    },
+    {
+      "start": 835.37,
+      "end": 835.45,
+      "text": "of"
+    },
+    {
+      "start": 835.45,
+      "end": 835.61,
+      "text": "is"
+    },
+    {
+      "start": 835.61,
+      "end": 835.85,
+      "text": "Blue"
+    },
+    {
+      "start": 835.85,
+      "end": 836.09,
+      "text": "Sky"
+    },
+    {
+      "start": 836.09,
+      "end": 836.33,
+      "text": "shuts"
+    },
+    {
+      "start": 836.33,
+      "end": 836.49,
+      "text": "down"
+    },
+    {
+      "start": 836.49,
+      "end": 836.81,
+      "text": "app"
+    },
+    {
+      "start": 836.8,
+      "end": 836.96,
+      "text": "view"
+    },
+    {
+      "start": 836.97,
+      "end": 837.37,
+      "text": "API"
+    },
+    {
+      "start": 837.37,
+      "end": 837.77,
+      "text": "access."
+    },
+    {
+      "start": 837.98,
+      "end": 838.22,
+      "text": "People"
+    },
+    {
+      "start": 838.22,
+      "end": 838.46,
+      "text": "are"
+    },
+    {
+      "start": 838.46,
+      "end": 838.78,
+      "text": "familiar"
+    },
+    {
+      "start": 838.78,
+      "end": 838.86,
+      "text": "with"
+    },
+    {
+      "start": 838.86,
+      "end": 839.02,
+      "text": "this"
+    },
+    {
+      "start": 839.02,
+      "end": 839.18,
+      "text": "because"
+    },
+    {
+      "start": 839.18,
+      "end": 839.34,
+      "text": "a"
+    },
+    {
+      "start": 839.34,
+      "end": 839.42,
+      "text": "lot"
+    },
+    {
+      "start": 839.42,
+      "end": 839.5,
+      "text": "of"
+    },
+    {
+      "start": 839.5,
+      "end": 839.82,
+      "text": "social"
+    },
+    {
+      "start": 839.82,
+      "end": 840.14,
+      "text": "companies"
+    },
+    {
+      "start": 840.14,
+      "end": 840.3,
+      "text": "in"
+    },
+    {
+      "start": 840.3,
+      "end": 840.38,
+      "text": "the"
+    },
+    {
+      "start": 840.38,
+      "end": 840.54,
+      "text": "past"
+    },
+    {
+      "start": 840.54,
+      "end": 840.78,
+      "text": "have"
+    },
+    {
+      "start": 840.78,
+      "end": 840.94,
+      "text": "done"
+    },
+    {
+      "start": 840.94,
+      "end": 841.34,
+      "text": "it."
+    },
+    {
+      "start": 841.34,
+      "end": 841.58,
+      "text": "This"
+    },
+    {
+      "start": 841.58,
+      "end": 841.74,
+      "text": "is"
+    },
+    {
+      "start": 841.74,
+      "end": 841.9,
+      "text": "actually"
+    },
+    {
+      "start": 841.9,
+      "end": 842.14,
+      "text": "sort"
+    },
+    {
+      "start": 842.14,
+      "end": 842.3,
+      "text": "of"
+    },
+    {
+      "start": 842.3,
+      "end": 842.46,
+      "text": "the"
+    },
+    {
+      "start": 842.46,
+      "end": 842.62,
+      "text": "threat"
+    },
+    {
+      "start": 842.62,
+      "end": 842.86,
+      "text": "that"
+    },
+    {
+      "start": 842.86,
+      "end": 843.1,
+      "text": "I'm"
+    },
+    {
+      "start": 843.1,
+      "end": 843.5,
+      "text": "least"
+    },
+    {
+      "start": 843.5,
+      "end": 844.06,
+      "text": "concerned"
+    },
+    {
+      "start": 844.06,
+      "end": 844.54,
+      "text": "about"
+    },
+    {
+      "start": 844.86,
+      "end": 845.26,
+      "text": "because"
+    },
+    {
+      "start": 845.26,
+      "end": 845.58,
+      "text": "data"
+    },
+    {
+      "start": 845.58,
+      "end": 845.9,
+      "text": "access"
+    },
+    {
+      "start": 845.9,
+      "end": 846.14,
+      "text": "is"
+    },
+    {
+      "start": 846.14,
+      "end": 846.46,
+      "text": "guaranteed"
+    },
+    {
+      "start": 846.46,
+      "end": 846.7,
+      "text": "by"
+    },
+    {
+      "start": 846.7,
+      "end": 846.86,
+      "text": "the"
+    },
+    {
+      "start": 846.86,
+      "end": 847.1,
+      "text": "open"
+    },
+    {
+      "start": 847.1,
+      "end": 847.58,
+      "text": "hosting"
+    },
+    {
+      "start": 847.58,
+      "end": 848.14,
+      "text": "PDS"
+    },
+    {
+      "start": 848.14,
+      "end": 848.7,
+      "text": "layer."
+    },
+    {
+      "start": 848.7,
+      "end": 848.94,
+      "text": "As"
+    },
+    {
+      "start": 848.94,
+      "end": 849.1,
+      "text": "long"
+    },
+    {
+      "start": 849.1,
+      "end": 849.26,
+      "text": "as"
+    },
+    {
+      "start": 849.26,
+      "end": 849.42,
+      "text": "the"
+    },
+    {
+      "start": 849.42,
+      "end": 849.74,
+      "text": "hosting"
+    },
+    {
+      "start": 849.74,
+      "end": 850.22,
+      "text": "layer,"
+    },
+    {
+      "start": 850.22,
+      "end": 850.62,
+      "text": "that's"
+    },
+    {
+      "start": 850.98,
+      "end": 851.22,
+      "text": "the"
+    },
+    {
+      "start": 851.22,
+      "end": 851.54,
+      "text": "network"
+    },
+    {
+      "start": 851.54,
+      "end": 852.02,
+      "text": "inherits"
+    },
+    {
+      "start": 852.01,
+      "end": 852.25,
+      "text": "its"
+    },
+    {
+      "start": 852.25,
+      "end": 852.97,
+      "text": "openness"
+    },
+    {
+      "start": 852.98,
+      "end": 853.3,
+      "text": "from"
+    },
+    {
+      "start": 853.29,
+      "end": 853.37,
+      "text": "the"
+    },
+    {
+      "start": 853.38,
+      "end": 853.78,
+      "text": "PDS"
+    },
+    {
+      "start": 853.77,
+      "end": 854.17,
+      "text": "layer."
+    },
+    {
+      "start": 854.17,
+      "end": 854.41,
+      "text": "And"
+    },
+    {
+      "start": 854.42,
+      "end": 854.58,
+      "text": "as"
+    },
+    {
+      "start": 854.58,
+      "end": 854.74,
+      "text": "long"
+    },
+    {
+      "start": 854.74,
+      "end": 854.9,
+      "text": "as"
+    },
+    {
+      "start": 854.89,
+      "end": 854.97,
+      "text": "the"
+    },
+    {
+      "start": 854.98,
+      "end": 855.3,
+      "text": "hosting"
+    },
+    {
+      "start": 855.29,
+      "end": 855.53,
+      "text": "layer"
+    },
+    {
+      "start": 855.54,
+      "end": 855.94,
+      "text": "remains"
+    },
+    {
+      "start": 855.93,
+      "end": 856.25,
+      "text": "locked"
+    },
+    {
+      "start": 856.25,
+      "end": 856.81,
+      "text": "open,"
+    },
+    {
+      "start": 857.29,
+      "end": 857.69,
+      "text": "then"
+    },
+    {
+      "start": 857.7,
+      "end": 858.18,
+      "text": "these"
+    },
+    {
+      "start": 858.17,
+      "end": 858.49,
+      "text": "other"
+    },
+    {
+      "start": 858.5,
+      "end": 858.82,
+      "text": "app"
+    },
+    {
+      "start": 858.82,
+      "end": 859.06,
+      "text": "view"
+    },
+    {
+      "start": 859.05,
+      "end": 859.61,
+      "text": "implementations"
+    },
+    {
+      "start": 859.62,
+      "end": 860.02,
+      "text": "can"
+    },
+    {
+      "start": 860.01,
+      "end": 860.41,
+      "text": "emerge"
+    },
+    {
+      "start": 860.42,
+      "end": 860.58,
+      "text": "as"
+    },
+    {
+      "start": 860.58,
+      "end": 860.74,
+      "text": "the"
+    },
+    {
+      "start": 860.74,
+      "end": 860.98,
+      "text": "need"
+    },
+    {
+      "start": 860.98,
+      "end": 861.54,
+      "text": "arises."
+    },
+    {
+      "start": 861.54,
+      "end": 861.86,
+      "text": "I've"
+    },
+    {
+      "start": 861.86,
+      "end": 862.26,
+      "text": "somewhat"
+    },
+    {
+      "start": 862.25,
+      "end": 862.81,
+      "text": "jokingly"
+    },
+    {
+      "start": 862.82,
+      "end": 862.98,
+      "text": "in"
+    },
+    {
+      "start": 862.98,
+      "end": 863.06,
+      "text": "the"
+    },
+    {
+      "start": 863.05,
+      "end": 863.21,
+      "text": "past"
+    },
+    {
+      "start": 863.22,
+      "end": 863.46,
+      "text": "called"
+    },
+    {
+      "start": 863.46,
+      "end": 863.62,
+      "text": "this"
+    },
+    {
+      "start": 863.62,
+      "end": 864.02,
+      "text": "lazy"
+    },
+    {
+      "start": 864.01,
+      "end": 865.05,
+      "text": "decentralization"
+    },
+    {
+      "start": 865.14,
+      "end": 865.46,
+      "text": "that"
+    },
+    {
+      "start": 865.46,
+      "end": 865.7,
+      "text": "it's"
+    },
+    {
+      "start": 865.86,
+      "end": 866.02,
+      "text": "If"
+    },
+    {
+      "start": 866.02,
+      "end": 866.26,
+      "text": "you"
+    },
+    {
+      "start": 866.26,
+      "end": 866.5,
+      "text": "trust"
+    },
+    {
+      "start": 866.5,
+      "end": 866.74,
+      "text": "that"
+    },
+    {
+      "start": 866.74,
+      "end": 866.98,
+      "text": "the"
+    },
+    {
+      "start": 866.98,
+      "end": 867.38,
+      "text": "hosting"
+    },
+    {
+      "start": 867.38,
+      "end": 867.7,
+      "text": "layer"
+    },
+    {
+      "start": 867.7,
+      "end": 867.86,
+      "text": "is"
+    },
+    {
+      "start": 867.86,
+      "end": 868.42,
+      "text": "open,"
+    },
+    {
+      "start": 868.5,
+      "end": 868.66,
+      "text": "then"
+    },
+    {
+      "start": 868.66,
+      "end": 868.82,
+      "text": "you"
+    },
+    {
+      "start": 868.82,
+      "end": 868.98,
+      "text": "don't"
+    },
+    {
+      "start": 868.98,
+      "end": 869.14,
+      "text": "need"
+    },
+    {
+      "start": 869.14,
+      "end": 869.3,
+      "text": "to"
+    },
+    {
+      "start": 869.3,
+      "end": 869.86,
+      "text": "decentralize"
+    },
+    {
+      "start": 869.86,
+      "end": 870.02,
+      "text": "the"
+    },
+    {
+      "start": 870.02,
+      "end": 870.18,
+      "text": "app"
+    },
+    {
+      "start": 870.18,
+      "end": 870.5,
+      "text": "layer"
+    },
+    {
+      "start": 870.5,
+      "end": 871.06,
+      "text": "yet."
+    },
+    {
+      "start": 871.46,
+      "end": 871.62,
+      "text": "But"
+    },
+    {
+      "start": 871.62,
+      "end": 871.78,
+      "text": "you"
+    },
+    {
+      "start": 871.78,
+      "end": 871.94,
+      "text": "have"
+    },
+    {
+      "start": 871.94,
+      "end": 872.02,
+      "text": "to"
+    },
+    {
+      "start": 872.02,
+      "end": 872.18,
+      "text": "trust"
+    },
+    {
+      "start": 872.18,
+      "end": 872.34,
+      "text": "that"
+    },
+    {
+      "start": 872.34,
+      "end": 872.42,
+      "text": "the"
+    },
+    {
+      "start": 872.42,
+      "end": 872.74,
+      "text": "hosting"
+    },
+    {
+      "start": 872.74,
+      "end": 872.9,
+      "text": "layer"
+    },
+    {
+      "start": 872.9,
+      "end": 873.06,
+      "text": "is"
+    },
+    {
+      "start": 873.06,
+      "end": 873.22,
+      "text": "open"
+    },
+    {
+      "start": 873.22,
+      "end": 873.46,
+      "text": "and"
+    },
+    {
+      "start": 873.46,
+      "end": 873.7,
+      "text": "we'll"
+    },
+    {
+      "start": 873.7,
+      "end": 873.78,
+      "text": "talk"
+    },
+    {
+      "start": 873.78,
+      "end": 873.94,
+      "text": "about"
+    },
+    {
+      "start": 873.94,
+      "end": 874.1,
+      "text": "that"
+    },
+    {
+      "start": 874.1,
+      "end": 874.26,
+      "text": "in"
+    },
+    {
+      "start": 874.26,
+      "end": 874.42,
+      "text": "a"
+    },
+    {
+      "start": 874.42,
+      "end": 874.9,
+      "text": "second."
+    },
+    {
+      "start": 875.46,
+      "end": 875.86,
+      "text": "Still,"
+    },
+    {
+      "start": 875.86,
+      "end": 875.94,
+      "text": "the"
+    },
+    {
+      "start": 875.94,
+      "end": 876.18,
+      "text": "things"
+    },
+    {
+      "start": 876.18,
+      "end": 876.26,
+      "text": "that"
+    },
+    {
+      "start": 876.26,
+      "end": 876.42,
+      "text": "we"
+    },
+    {
+      "start": 876.42,
+      "end": 876.58,
+      "text": "need"
+    },
+    {
+      "start": 876.58,
+      "end": 876.74,
+      "text": "for"
+    },
+    {
+      "start": 876.74,
+      "end": 876.98,
+      "text": "this"
+    },
+    {
+      "start": 876.98,
+      "end": 877.46,
+      "text": "are"
+    },
+    {
+      "start": 877.46,
+      "end": 877.7,
+      "text": "tools"
+    },
+    {
+      "start": 877.7,
+      "end": 878.02,
+      "text": "for"
+    },
+    {
+      "start": 878.02,
+      "end": 878.58,
+      "text": "backfilling"
+    },
+    {
+      "start": 878.58,
+      "end": 878.74,
+      "text": "the"
+    },
+    {
+      "start": 878.74,
+      "end": 878.98,
+      "text": "network"
+    },
+    {
+      "start": 878.98,
+      "end": 879.3,
+      "text": "and"
+    },
+    {
+      "start": 879.3,
+      "end": 879.62,
+      "text": "syncing"
+    },
+    {
+      "start": 879.62,
+      "end": 879.86,
+      "text": "the"
+    },
+    {
+      "start": 879.86,
+      "end": 880.26,
+      "text": "network"
+    },
+    {
+      "start": 880.34,
+      "end": 880.58,
+      "text": "and"
+    },
+    {
+      "start": 880.58,
+      "end": 880.9,
+      "text": "also"
+    },
+    {
+      "start": 880.89,
+      "end": 881.13,
+      "text": "app"
+    },
+    {
+      "start": 881.13,
+      "end": 881.37,
+      "text": "view"
+    },
+    {
+      "start": 881.38,
+      "end": 882.18,
+      "text": "implementation"
+    },
+    {
+      "start": 882.18,
+      "end": 882.9,
+      "text": "code."
+    },
+    {
+      "start": 885.13,
+      "end": 885.29,
+      "text": "So"
+    },
+    {
+      "start": 885.3,
+      "end": 885.62,
+      "text": "now,"
+    },
+    {
+      "start": 885.62,
+      "end": 885.78,
+      "text": "to"
+    },
+    {
+      "start": 885.77,
+      "end": 885.93,
+      "text": "talk"
+    },
+    {
+      "start": 885.93,
+      "end": 886.17,
+      "text": "about"
+    },
+    {
+      "start": 886.18,
+      "end": 886.5,
+      "text": "if"
+    },
+    {
+      "start": 886.5,
+      "end": 886.58,
+      "text": "we"
+    },
+    {
+      "start": 886.58,
+      "end": 886.9,
+      "text": "screwed"
+    },
+    {
+      "start": 886.89,
+      "end": 887.05,
+      "text": "up"
+    },
+    {
+      "start": 887.05,
+      "end": 887.13,
+      "text": "the"
+    },
+    {
+      "start": 887.13,
+      "end": 887.37,
+      "text": "hosting"
+    },
+    {
+      "start": 887.38,
+      "end": 887.78,
+      "text": "layer,"
+    },
+    {
+      "start": 887.77,
+      "end": 887.85,
+      "text": "this"
+    },
+    {
+      "start": 887.86,
+      "end": 888.02,
+      "text": "would"
+    },
+    {
+      "start": 888.01,
+      "end": 888.17,
+      "text": "be"
+    },
+    {
+      "start": 888.18,
+      "end": 888.34,
+      "text": "Blue"
+    },
+    {
+      "start": 888.34,
+      "end": 888.58,
+      "text": "Sky"
+    },
+    {
+      "start": 888.58,
+      "end": 888.9,
+      "text": "shutting"
+    },
+    {
+      "start": 888.89,
+      "end": 889.13,
+      "text": "down"
+    },
+    {
+      "start": 889.13,
+      "end": 889.61,
+      "text": "access"
+    },
+    {
+      "start": 889.62,
+      "end": 889.86,
+      "text": "to"
+    },
+    {
+      "start": 889.86,
+      "end": 890.1,
+      "text": "the"
+    },
+    {
+      "start": 890.1,
+      "end": 890.66,
+      "text": "PDS"
+    },
+    {
+      "start": 890.65,
+      "end": 890.97,
+      "text": "or"
+    },
+    {
+      "start": 890.98,
+      "end": 891.3,
+      "text": "access"
+    },
+    {
+      "start": 891.3,
+      "end": 891.46,
+      "text": "to"
+    },
+    {
+      "start": 891.46,
+      "end": 891.54,
+      "text": "the"
+    },
+    {
+      "start": 891.54,
+      "end": 891.78,
+      "text": "open"
+    },
+    {
+      "start": 891.77,
+      "end": 892.01,
+      "text": "data"
+    },
+    {
+      "start": 892.01,
+      "end": 892.33,
+      "text": "that's"
+    },
+    {
+      "start": 892.34,
+      "end": 892.5,
+      "text": "hosted"
+    },
+    {
+      "start": 892.5,
+      "end": 892.66,
+      "text": "by"
+    },
+    {
+      "start": 892.65,
+      "end": 892.81,
+      "text": "the"
+    },
+    {
+      "start": 892.82,
+      "end": 893.22,
+      "text": "PDS."
+    },
+    {
+      "start": 894.28,
+      "end": 894.52,
+      "text": "To"
+    },
+    {
+      "start": 894.52,
+      "end": 894.84,
+      "text": "note,"
+    },
+    {
+      "start": 894.84,
+      "end": 895.08,
+      "text": "Blue"
+    },
+    {
+      "start": 895.08,
+      "end": 895.32,
+      "text": "Sky"
+    },
+    {
+      "start": 895.48,
+      "end": 895.64,
+      "text": "if"
+    },
+    {
+      "start": 895.64,
+      "end": 895.8,
+      "text": "Blue"
+    },
+    {
+      "start": 895.8,
+      "end": 895.96,
+      "text": "Sky"
+    },
+    {
+      "start": 895.96,
+      "end": 896.2,
+      "text": "were"
+    },
+    {
+      "start": 896.2,
+      "end": 896.36,
+      "text": "to"
+    },
+    {
+      "start": 896.36,
+      "end": 896.52,
+      "text": "do"
+    },
+    {
+      "start": 896.52,
+      "end": 896.76,
+      "text": "this,"
+    },
+    {
+      "start": 896.76,
+      "end": 896.92,
+      "text": "it"
+    },
+    {
+      "start": 896.92,
+      "end": 897.64,
+      "text": "destroys"
+    },
+    {
+      "start": 897.64,
+      "end": 897.96,
+      "text": "all"
+    },
+    {
+      "start": 897.96,
+      "end": 898.04,
+      "text": "of"
+    },
+    {
+      "start": 898.04,
+      "end": 898.2,
+      "text": "the"
+    },
+    {
+      "start": 898.2,
+      "end": 898.76,
+      "text": "feeds,"
+    },
+    {
+      "start": 898.76,
+      "end": 899.24,
+      "text": "apps,"
+    },
+    {
+      "start": 899.24,
+      "end": 899.32,
+      "text": "and"
+    },
+    {
+      "start": 899.32,
+      "end": 899.8,
+      "text": "labelers"
+    },
+    {
+      "start": 899.8,
+      "end": 900.2,
+      "text": "running"
+    },
+    {
+      "start": 900.2,
+      "end": 900.36,
+      "text": "on"
+    },
+    {
+      "start": 900.36,
+      "end": 900.44,
+      "text": "the"
+    },
+    {
+      "start": 900.44,
+      "end": 901.08,
+      "text": "protocol."
+    },
+    {
+      "start": 901.16,
+      "end": 901.4,
+      "text": "So,"
+    },
+    {
+      "start": 901.4,
+      "end": 901.48,
+      "text": "the"
+    },
+    {
+      "start": 901.48,
+      "end": 901.72,
+      "text": "pain"
+    },
+    {
+      "start": 901.72,
+      "end": 901.88,
+      "text": "of"
+    },
+    {
+      "start": 901.88,
+      "end": 902.28,
+      "text": "destroying"
+    },
+    {
+      "start": 902.28,
+      "end": 902.44,
+      "text": "the"
+    },
+    {
+      "start": 902.44,
+      "end": 902.68,
+      "text": "network"
+    },
+    {
+      "start": 902.68,
+      "end": 902.84,
+      "text": "of"
+    },
+    {
+      "start": 902.84,
+      "end": 903.16,
+      "text": "open"
+    },
+    {
+      "start": 903.16,
+      "end": 903.96,
+      "text": "applications"
+    },
+    {
+      "start": 903.96,
+      "end": 904.36,
+      "text": "needs"
+    },
+    {
+      "start": 904.36,
+      "end": 904.44,
+      "text": "to"
+    },
+    {
+      "start": 904.44,
+      "end": 904.68,
+      "text": "be"
+    },
+    {
+      "start": 904.68,
+      "end": 905,
+      "text": "severe"
+    },
+    {
+      "start": 905,
+      "end": 905.24,
+      "text": "enough"
+    },
+    {
+      "start": 905.24,
+      "end": 905.56,
+      "text": "that"
+    },
+    {
+      "start": 905.56,
+      "end": 905.72,
+      "text": "Blue"
+    },
+    {
+      "start": 905.72,
+      "end": 905.96,
+      "text": "Sky"
+    },
+    {
+      "start": 905.96,
+      "end": 906.36,
+      "text": "cannot"
+    },
+    {
+      "start": 906.36,
+      "end": 906.68,
+      "text": "consider"
+    },
+    {
+      "start": 906.68,
+      "end": 907.08,
+      "text": "shutting"
+    },
+    {
+      "start": 907.08,
+      "end": 907.32,
+      "text": "down"
+    },
+    {
+      "start": 907.32,
+      "end": 907.48,
+      "text": "our"
+    },
+    {
+      "start": 907.48,
+      "end": 908.44,
+      "text": "PDS"
+    },
+    {
+      "start": 908.75,
+      "end": 909.31,
+      "text": "PDS"
+    },
+    {
+      "start": 909.3,
+      "end": 910.02,
+      "text": "access."
+    },
+    {
+      "start": 910.83,
+      "end": 911.07,
+      "text": "A"
+    },
+    {
+      "start": 911.07,
+      "end": 911.55,
+      "text": "smaller"
+    },
+    {
+      "start": 911.54,
+      "end": 911.78,
+      "text": "version"
+    },
+    {
+      "start": 911.78,
+      "end": 911.86,
+      "text": "of"
+    },
+    {
+      "start": 911.87,
+      "end": 912.03,
+      "text": "this"
+    },
+    {
+      "start": 912.02,
+      "end": 912.34,
+      "text": "attack"
+    },
+    {
+      "start": 912.35,
+      "end": 912.51,
+      "text": "would"
+    },
+    {
+      "start": 912.5,
+      "end": 912.66,
+      "text": "be"
+    },
+    {
+      "start": 912.66,
+      "end": 912.98,
+      "text": "Blue"
+    },
+    {
+      "start": 912.99,
+      "end": 913.23,
+      "text": "Sky"
+    },
+    {
+      "start": 913.23,
+      "end": 913.63,
+      "text": "based"
+    },
+    {
+      "start": 913.63,
+      "end": 913.95,
+      "text": "stop"
+    },
+    {
+      "start": 913.95,
+      "end": 914.35,
+      "text": "serving"
+    },
+    {
+      "start": 914.35,
+      "end": 914.67,
+      "text": "data"
+    },
+    {
+      "start": 914.66,
+      "end": 914.9,
+      "text": "to"
+    },
+    {
+      "start": 914.9,
+      "end": 915.46,
+      "text": "particular"
+    },
+    {
+      "start": 915.46,
+      "end": 916.1,
+      "text": "competitors."
+    },
+    {
+      "start": 916.11,
+      "end": 916.27,
+      "text": "So,"
+    },
+    {
+      "start": 916.26,
+      "end": 916.42,
+      "text": "if"
+    },
+    {
+      "start": 916.42,
+      "end": 916.66,
+      "text": "one"
+    },
+    {
+      "start": 916.66,
+      "end": 917.22,
+      "text": "big"
+    },
+    {
+      "start": 917.71,
+      "end": 918.27,
+      "text": "competitor"
+    },
+    {
+      "start": 918.26,
+      "end": 918.74,
+      "text": "emerges"
+    },
+    {
+      "start": 918.75,
+      "end": 918.91,
+      "text": "in"
+    },
+    {
+      "start": 918.9,
+      "end": 919.06,
+      "text": "the"
+    },
+    {
+      "start": 919.07,
+      "end": 919.71,
+      "text": "ecosystem,"
+    },
+    {
+      "start": 919.71,
+      "end": 919.95,
+      "text": "maybe"
+    },
+    {
+      "start": 919.95,
+      "end": 920.11,
+      "text": "we"
+    },
+    {
+      "start": 920.11,
+      "end": 920.35,
+      "text": "keep"
+    },
+    {
+      "start": 920.35,
+      "end": 920.75,
+      "text": "sharing"
+    },
+    {
+      "start": 920.75,
+      "end": 920.99,
+      "text": "data"
+    },
+    {
+      "start": 920.99,
+      "end": 921.23,
+      "text": "to"
+    },
+    {
+      "start": 921.23,
+      "end": 921.39,
+      "text": "all"
+    },
+    {
+      "start": 921.38,
+      "end": 921.46,
+      "text": "of"
+    },
+    {
+      "start": 921.46,
+      "end": 921.62,
+      "text": "the"
+    },
+    {
+      "start": 921.63,
+      "end": 921.87,
+      "text": "feeds"
+    },
+    {
+      "start": 921.87,
+      "end": 922.03,
+      "text": "and"
+    },
+    {
+      "start": 922.02,
+      "end": 922.42,
+      "text": "labelers"
+    },
+    {
+      "start": 922.42,
+      "end": 922.66,
+      "text": "out"
+    },
+    {
+      "start": 922.66,
+      "end": 922.82,
+      "text": "there,"
+    },
+    {
+      "start": 922.89,
+      "end": 923.21,
+      "text": "but"
+    },
+    {
+      "start": 923.21,
+      "end": 923.29,
+      "text": "we"
+    },
+    {
+      "start": 923.29,
+      "end": 923.53,
+      "text": "cut"
+    },
+    {
+      "start": 923.53,
+      "end": 923.77,
+      "text": "off"
+    },
+    {
+      "start": 923.77,
+      "end": 924.33,
+      "text": "access"
+    },
+    {
+      "start": 924.33,
+      "end": 924.49,
+      "text": "to"
+    },
+    {
+      "start": 924.49,
+      "end": 924.73,
+      "text": "that"
+    },
+    {
+      "start": 924.73,
+      "end": 925.05,
+      "text": "one"
+    },
+    {
+      "start": 925.05,
+      "end": 925.69,
+      "text": "larger"
+    },
+    {
+      "start": 925.69,
+      "end": 926.49,
+      "text": "competitor."
+    },
+    {
+      "start": 926.97,
+      "end": 927.13,
+      "text": "The"
+    },
+    {
+      "start": 927.13,
+      "end": 927.29,
+      "text": "things"
+    },
+    {
+      "start": 927.29,
+      "end": 927.45,
+      "text": "that"
+    },
+    {
+      "start": 927.45,
+      "end": 927.53,
+      "text": "we"
+    },
+    {
+      "start": 927.53,
+      "end": 927.69,
+      "text": "need"
+    },
+    {
+      "start": 927.69,
+      "end": 927.85,
+      "text": "to"
+    },
+    {
+      "start": 927.85,
+      "end": 928.09,
+      "text": "prevent"
+    },
+    {
+      "start": 928.09,
+      "end": 928.33,
+      "text": "this"
+    },
+    {
+      "start": 928.33,
+      "end": 928.65,
+      "text": "are"
+    },
+    {
+      "start": 928.65,
+      "end": 929.29,
+      "text": "a"
+    },
+    {
+      "start": 929.29,
+      "end": 929.69,
+      "text": "thriving"
+    },
+    {
+      "start": 929.69,
+      "end": 930.01,
+      "text": "network"
+    },
+    {
+      "start": 930.01,
+      "end": 930.41,
+      "text": "built"
+    },
+    {
+      "start": 930.41,
+      "end": 930.57,
+      "text": "on"
+    },
+    {
+      "start": 930.57,
+      "end": 930.81,
+      "text": "open"
+    },
+    {
+      "start": 930.81,
+      "end": 931.21,
+      "text": "data."
+    },
+    {
+      "start": 931.21,
+      "end": 931.37,
+      "text": "If"
+    },
+    {
+      "start": 931.37,
+      "end": 931.61,
+      "text": "people"
+    },
+    {
+      "start": 931.61,
+      "end": 931.77,
+      "text": "are"
+    },
+    {
+      "start": 931.77,
+      "end": 932.17,
+      "text": "relying"
+    },
+    {
+      "start": 932.17,
+      "end": 932.33,
+      "text": "on"
+    },
+    {
+      "start": 932.33,
+      "end": 932.57,
+      "text": "open"
+    },
+    {
+      "start": 932.57,
+      "end": 932.97,
+      "text": "data,"
+    },
+    {
+      "start": 932.97,
+      "end": 933.13,
+      "text": "then"
+    },
+    {
+      "start": 933.13,
+      "end": 933.37,
+      "text": "we're"
+    },
+    {
+      "start": 933.37,
+      "end": 933.93,
+      "text": "incentivized"
+    },
+    {
+      "start": 933.93,
+      "end": 934.09,
+      "text": "to"
+    },
+    {
+      "start": 934.09,
+      "end": 934.25,
+      "text": "not"
+    },
+    {
+      "start": 934.25,
+      "end": 934.49,
+      "text": "cut"
+    },
+    {
+      "start": 934.49,
+      "end": 934.65,
+      "text": "off"
+    },
+    {
+      "start": 934.65,
+      "end": 934.97,
+      "text": "access"
+    },
+    {
+      "start": 934.97,
+      "end": 935.13,
+      "text": "to"
+    },
+    {
+      "start": 935.13,
+      "end": 935.29,
+      "text": "it."
+    },
+    {
+      "start": 935.71,
+      "end": 935.95,
+      "text": "And"
+    },
+    {
+      "start": 935.95,
+      "end": 936.35,
+      "text": "then,"
+    },
+    {
+      "start": 936.35,
+      "end": 936.91,
+      "text": "specifically"
+    },
+    {
+      "start": 936.9,
+      "end": 937.14,
+      "text": "on"
+    },
+    {
+      "start": 937.14,
+      "end": 937.3,
+      "text": "this"
+    },
+    {
+      "start": 937.3,
+      "end": 937.62,
+      "text": "cutting"
+    },
+    {
+      "start": 937.63,
+      "end": 937.79,
+      "text": "off"
+    },
+    {
+      "start": 937.78,
+      "end": 938.1,
+      "text": "access"
+    },
+    {
+      "start": 938.11,
+      "end": 938.35,
+      "text": "to"
+    },
+    {
+      "start": 938.35,
+      "end": 938.67,
+      "text": "particular"
+    },
+    {
+      "start": 938.66,
+      "end": 939.62,
+      "text": "competitors,"
+    },
+    {
+      "start": 939.63,
+      "end": 939.87,
+      "text": "all"
+    },
+    {
+      "start": 939.87,
+      "end": 940.03,
+      "text": "of"
+    },
+    {
+      "start": 940.02,
+      "end": 940.1,
+      "text": "the"
+    },
+    {
+      "start": 940.11,
+      "end": 940.43,
+      "text": "data"
+    },
+    {
+      "start": 940.42,
+      "end": 940.66,
+      "text": "is"
+    },
+    {
+      "start": 940.66,
+      "end": 941.06,
+      "text": "signed"
+    },
+    {
+      "start": 941.07,
+      "end": 941.23,
+      "text": "and"
+    },
+    {
+      "start": 941.23,
+      "end": 942.43,
+      "text": "rebroadcastable."
+    },
+    {
+      "start": 942.42,
+      "end": 942.58,
+      "text": "That"
+    },
+    {
+      "start": 942.59,
+      "end": 942.83,
+      "text": "means"
+    },
+    {
+      "start": 942.83,
+      "end": 942.99,
+      "text": "that"
+    },
+    {
+      "start": 942.99,
+      "end": 943.47,
+      "text": "you"
+    },
+    {
+      "start": 943.47,
+      "end": 943.63,
+      "text": "can"
+    },
+    {
+      "start": 943.63,
+      "end": 943.79,
+      "text": "get"
+    },
+    {
+      "start": 943.78,
+      "end": 943.86,
+      "text": "it"
+    },
+    {
+      "start": 943.87,
+      "end": 944.03,
+      "text": "from"
+    },
+    {
+      "start": 944.02,
+      "end": 944.18,
+      "text": "any"
+    },
+    {
+      "start": 944.18,
+      "end": 944.5,
+      "text": "source."
+    },
+    {
+      "start": 944.5,
+      "end": 944.66,
+      "text": "You"
+    },
+    {
+      "start": 944.66,
+      "end": 944.74,
+      "text": "can"
+    },
+    {
+      "start": 944.75,
+      "end": 944.83,
+      "text": "get"
+    },
+    {
+      "start": 944.83,
+      "end": 944.99,
+      "text": "it"
+    },
+    {
+      "start": 944.99,
+      "end": 945.15,
+      "text": "from"
+    },
+    {
+      "start": 945.14,
+      "end": 945.46,
+      "text": "the"
+    },
+    {
+      "start": 945.47,
+      "end": 945.71,
+      "text": "Blue"
+    },
+    {
+      "start": 945.71,
+      "end": 945.95,
+      "text": "Sky"
+    },
+    {
+      "start": 945.95,
+      "end": 946.35,
+      "text": "PDS"
+    },
+    {
+      "start": 946.35,
+      "end": 946.59,
+      "text": "or"
+    },
+    {
+      "start": 946.59,
+      "end": 946.67,
+      "text": "you"
+    },
+    {
+      "start": 946.66,
+      "end": 946.82,
+      "text": "can"
+    },
+    {
+      "start": 946.83,
+      "end": 946.91,
+      "text": "get"
+    },
+    {
+      "start": 946.9,
+      "end": 946.98,
+      "text": "it"
+    },
+    {
+      "start": 946.99,
+      "end": 947.15,
+      "text": "from"
+    },
+    {
+      "start": 947.14,
+      "end": 947.38,
+      "text": "another"
+    },
+    {
+      "start": 947.38,
+      "end": 947.86,
+      "text": "PDS."
+    },
+    {
+      "start": 948.22,
+      "end": 948.78,
+      "text": "So,"
+    },
+    {
+      "start": 948.78,
+      "end": 948.94,
+      "text": "we"
+    },
+    {
+      "start": 948.94,
+      "end": 949.1,
+      "text": "need"
+    },
+    {
+      "start": 949.1,
+      "end": 949.58,
+      "text": "multiple"
+    },
+    {
+      "start": 949.58,
+      "end": 950.06,
+      "text": "sources"
+    },
+    {
+      "start": 950.06,
+      "end": 950.22,
+      "text": "to"
+    },
+    {
+      "start": 950.22,
+      "end": 950.38,
+      "text": "get"
+    },
+    {
+      "start": 950.38,
+      "end": 950.7,
+      "text": "data"
+    },
+    {
+      "start": 950.7,
+      "end": 951.26,
+      "text": "from."
+    },
+    {
+      "start": 954.86,
+      "end": 955.1,
+      "text": "The"
+    },
+    {
+      "start": 955.1,
+      "end": 955.5,
+      "text": "next"
+    },
+    {
+      "start": 955.5,
+      "end": 955.82,
+      "text": "sort"
+    },
+    {
+      "start": 955.82,
+      "end": 955.98,
+      "text": "of"
+    },
+    {
+      "start": 955.98,
+      "end": 956.22,
+      "text": "threat"
+    },
+    {
+      "start": 956.22,
+      "end": 956.46,
+      "text": "is"
+    },
+    {
+      "start": 956.46,
+      "end": 956.78,
+      "text": "Blue"
+    },
+    {
+      "start": 956.78,
+      "end": 957.1,
+      "text": "Sky"
+    },
+    {
+      "start": 957.1,
+      "end": 957.5,
+      "text": "stops"
+    },
+    {
+      "start": 957.5,
+      "end": 957.98,
+      "text": "crawling"
+    },
+    {
+      "start": 957.98,
+      "end": 958.22,
+      "text": "non"
+    },
+    {
+      "start": 958.22,
+      "end": 958.54,
+      "text": "Blue"
+    },
+    {
+      "start": 958.54,
+      "end": 958.78,
+      "text": "Sky"
+    },
+    {
+      "start": 958.78,
+      "end": 959.5,
+      "text": "PDSs."
+    },
+    {
+      "start": 959.5,
+      "end": 959.58,
+      "text": "So,"
+    },
+    {
+      "start": 959.58,
+      "end": 959.82,
+      "text": "these"
+    },
+    {
+      "start": 959.82,
+      "end": 959.98,
+      "text": "are"
+    },
+    {
+      "start": 959.98,
+      "end": 960.14,
+      "text": "folks"
+    },
+    {
+      "start": 960.14,
+      "end": 960.3,
+      "text": "that"
+    },
+    {
+      "start": 960.3,
+      "end": 960.46,
+      "text": "have"
+    },
+    {
+      "start": 960.46,
+      "end": 960.78,
+      "text": "migrated"
+    },
+    {
+      "start": 960.78,
+      "end": 961.02,
+      "text": "their"
+    },
+    {
+      "start": 961.02,
+      "end": 961.26,
+      "text": "account"
+    },
+    {
+      "start": 961.26,
+      "end": 961.5,
+      "text": "off"
+    },
+    {
+      "start": 961.5,
+      "end": 961.66,
+      "text": "of"
+    },
+    {
+      "start": 961.66,
+      "end": 961.82,
+      "text": "the"
+    },
+    {
+      "start": 961.82,
+      "end": 961.98,
+      "text": "Blue"
+    },
+    {
+      "start": 961.98,
+      "end": 962.14,
+      "text": "Sky"
+    },
+    {
+      "start": 962.14,
+      "end": 963.1,
+      "text": "PDS"
+    },
+    {
+      "start": 962.72,
+      "end": 963.04,
+      "text": "and"
+    },
+    {
+      "start": 963.04,
+      "end": 963.12,
+      "text": "the"
+    },
+    {
+      "start": 963.12,
+      "end": 963.36,
+      "text": "Blue"
+    },
+    {
+      "start": 963.36,
+      "end": 963.52,
+      "text": "Sky"
+    },
+    {
+      "start": 963.51,
+      "end": 963.83,
+      "text": "app"
+    },
+    {
+      "start": 963.84,
+      "end": 964.16,
+      "text": "view"
+    },
+    {
+      "start": 964.15,
+      "end": 964.63,
+      "text": "stops"
+    },
+    {
+      "start": 964.63,
+      "end": 965.11,
+      "text": "indexing"
+    },
+    {
+      "start": 965.12,
+      "end": 965.36,
+      "text": "non"
+    },
+    {
+      "start": 965.36,
+      "end": 965.68,
+      "text": "Blue"
+    },
+    {
+      "start": 965.68,
+      "end": 965.84,
+      "text": "Sky"
+    },
+    {
+      "start": 965.84,
+      "end": 966.56,
+      "text": "PDS"
+    },
+    {
+      "start": 966.56,
+      "end": 967.28,
+      "text": "data."
+    },
+    {
+      "start": 967.27,
+      "end": 967.51,
+      "text": "Their"
+    },
+    {
+      "start": 967.51,
+      "end": 968.15,
+      "text": "motivation"
+    },
+    {
+      "start": 968.15,
+      "end": 968.31,
+      "text": "to"
+    },
+    {
+      "start": 968.32,
+      "end": 968.48,
+      "text": "do"
+    },
+    {
+      "start": 968.48,
+      "end": 968.64,
+      "text": "that"
+    },
+    {
+      "start": 968.63,
+      "end": 968.79,
+      "text": "would"
+    },
+    {
+      "start": 968.8,
+      "end": 968.96,
+      "text": "be"
+    },
+    {
+      "start": 968.96,
+      "end": 969.12,
+      "text": "to"
+    },
+    {
+      "start": 969.12,
+      "end": 969.76,
+      "text": "monopolize"
+    },
+    {
+      "start": 969.75,
+      "end": 970.47,
+      "text": "hosting."
+    },
+    {
+      "start": 972.24,
+      "end": 972.48,
+      "text": "What"
+    },
+    {
+      "start": 972.48,
+      "end": 972.64,
+      "text": "we"
+    },
+    {
+      "start": 972.63,
+      "end": 972.79,
+      "text": "need"
+    },
+    {
+      "start": 972.8,
+      "end": 972.88,
+      "text": "to"
+    },
+    {
+      "start": 972.88,
+      "end": 973.12,
+      "text": "prevent"
+    },
+    {
+      "start": 973.12,
+      "end": 973.36,
+      "text": "this"
+    },
+    {
+      "start": 973.36,
+      "end": 973.68,
+      "text": "is"
+    },
+    {
+      "start": 973.68,
+      "end": 974.08,
+      "text": "a"
+    },
+    {
+      "start": 974.08,
+      "end": 974.48,
+      "text": "critical"
+    },
+    {
+      "start": 974.48,
+      "end": 974.72,
+      "text": "mass"
+    },
+    {
+      "start": 974.72,
+      "end": 974.88,
+      "text": "of"
+    },
+    {
+      "start": 974.88,
+      "end": 975.28,
+      "text": "users"
+    },
+    {
+      "start": 975.27,
+      "end": 975.51,
+      "text": "on"
+    },
+    {
+      "start": 975.51,
+      "end": 975.67,
+      "text": "non"
+    },
+    {
+      "start": 975.68,
+      "end": 975.92,
+      "text": "Blue"
+    },
+    {
+      "start": 975.92,
+      "end": 976.16,
+      "text": "Sky"
+    },
+    {
+      "start": 976.15,
+      "end": 976.87,
+      "text": "PDSs"
+    },
+    {
+      "start": 976.88,
+      "end": 977.12,
+      "text": "and"
+    },
+    {
+      "start": 977.12,
+      "end": 977.44,
+      "text": "other"
+    },
+    {
+      "start": 977.43,
+      "end": 977.91,
+      "text": "applications"
+    },
+    {
+      "start": 977.67,
+      "end": 977.99,
+      "text": "applications"
+    },
+    {
+      "start": 977.92,
+      "end": 978.16,
+      "text": "that"
+    },
+    {
+      "start": 977.99,
+      "end": 978.15,
+      "text": "that"
+    },
+    {
+      "start": 978.15,
+      "end": 978.39,
+      "text": "do"
+    },
+    {
+      "start": 978.15,
+      "end": 978.39,
+      "text": "do"
+    },
+    {
+      "start": 978.39,
+      "end": 978.71,
+      "text": "index"
+    },
+    {
+      "start": 978.39,
+      "end": 978.71,
+      "text": "index"
+    },
+    {
+      "start": 978.71,
+      "end": 978.95,
+      "text": "non"
+    },
+    {
+      "start": 978.72,
+      "end": 978.96,
+      "text": "non"
+    },
+    {
+      "start": 978.95,
+      "end": 979.11,
+      "text": "Blue"
+    },
+    {
+      "start": 978.96,
+      "end": 979.12,
+      "text": "Blue"
+    },
+    {
+      "start": 979.11,
+      "end": 979.27,
+      "text": "Sky"
+    },
+    {
+      "start": 979.12,
+      "end": 979.28,
+      "text": "Sky"
+    },
+    {
+      "start": 979.27,
+      "end": 979.75,
+      "text": "PDS"
+    },
+    {
+      "start": 979.27,
+      "end": 979.75,
+      "text": "PDS"
+    },
+    {
+      "start": 979.75,
+      "end": 980.31,
+      "text": "data."
+    },
+    {
+      "start": 979.75,
+      "end": 979.99,
+      "text": "Data."
+    },
+    {
+      "start": 980.47,
+      "end": 980.63,
+      "text": "And"
+    },
+    {
+      "start": 980.63,
+      "end": 980.79,
+      "text": "that"
+    },
+    {
+      "start": 980.87,
+      "end": 981.03,
+      "text": "I"
+    },
+    {
+      "start": 981.03,
+      "end": 981.19,
+      "text": "wanna"
+    },
+    {
+      "start": 981.19,
+      "end": 981.43,
+      "text": "call"
+    },
+    {
+      "start": 981.43,
+      "end": 981.59,
+      "text": "out"
+    },
+    {
+      "start": 981.59,
+      "end": 981.75,
+      "text": "that"
+    },
+    {
+      "start": 981.75,
+      "end": 982.23,
+      "text": "that"
+    },
+    {
+      "start": 982.23,
+      "end": 982.71,
+      "text": "critical"
+    },
+    {
+      "start": 982.71,
+      "end": 983.35,
+      "text": "mass"
+    },
+    {
+      "start": 983.59,
+      "end": 984.31,
+      "text": "basically,"
+    },
+    {
+      "start": 984.31,
+      "end": 984.39,
+      "text": "we"
+    },
+    {
+      "start": 984.39,
+      "end": 984.55,
+      "text": "need"
+    },
+    {
+      "start": 984.55,
+      "end": 984.63,
+      "text": "the"
+    },
+    {
+      "start": 984.63,
+      "end": 984.87,
+      "text": "critical"
+    },
+    {
+      "start": 984.87,
+      "end": 985.11,
+      "text": "mass"
+    },
+    {
+      "start": 985.11,
+      "end": 985.35,
+      "text": "because"
+    },
+    {
+      "start": 985.35,
+      "end": 985.51,
+      "text": "if"
+    },
+    {
+      "start": 985.51,
+      "end": 985.67,
+      "text": "Blue"
+    },
+    {
+      "start": 985.67,
+      "end": 985.91,
+      "text": "Sky"
+    },
+    {
+      "start": 985.91,
+      "end": 986.15,
+      "text": "were"
+    },
+    {
+      "start": 986.15,
+      "end": 986.39,
+      "text": "to"
+    },
+    {
+      "start": 986.39,
+      "end": 986.63,
+      "text": "stop"
+    },
+    {
+      "start": 986.63,
+      "end": 987.11,
+      "text": "indexing"
+    },
+    {
+      "start": 987.11,
+      "end": 987.59,
+      "text": "this,"
+    },
+    {
+      "start": 987.59,
+      "end": 987.67,
+      "text": "you"
+    },
+    {
+      "start": 987.67,
+      "end": 987.91,
+      "text": "needed"
+    },
+    {
+      "start": 987.91,
+      "end": 988.07,
+      "text": "to"
+    },
+    {
+      "start": 988.07,
+      "end": 988.39,
+      "text": "screw"
+    },
+    {
+      "start": 988.39,
+      "end": 988.55,
+      "text": "up"
+    },
+    {
+      "start": 988.55,
+      "end": 988.95,
+      "text": "people's"
+    },
+    {
+      "start": 988.95,
+      "end": 989.51,
+      "text": "experience"
+    },
+    {
+      "start": 989.51,
+      "end": 989.83,
+      "text": "of"
+    },
+    {
+      "start": 989.83,
+      "end": 989.99,
+      "text": "the"
+    },
+    {
+      "start": 989.99,
+      "end": 990.23,
+      "text": "app."
+    },
+    {
+      "start": 990.23,
+      "end": 990.55,
+      "text": "They"
+    },
+    {
+      "start": 990.54,
+      "end": 990.7,
+      "text": "would"
+    },
+    {
+      "start": 990.7,
+      "end": 990.78,
+      "text": "get"
+    },
+    {
+      "start": 990.78,
+      "end": 991.02,
+      "text": "pissed"
+    },
+    {
+      "start": 991.02,
+      "end": 991.26,
+      "text": "because"
+    },
+    {
+      "start": 991.26,
+      "end": 991.5,
+      "text": "there's"
+    },
+    {
+      "start": 991.5,
+      "end": 991.74,
+      "text": "data"
+    },
+    {
+      "start": 991.75,
+      "end": 991.91,
+      "text": "that"
+    },
+    {
+      "start": 991.9,
+      "end": 992.06,
+      "text": "they"
+    },
+    {
+      "start": 992.07,
+      "end": 992.23,
+      "text": "wanna"
+    },
+    {
+      "start": 992.23,
+      "end": 992.55,
+      "text": "see"
+    },
+    {
+      "start": 992.54,
+      "end": 992.78,
+      "text": "that"
+    },
+    {
+      "start": 992.78,
+      "end": 993.02,
+      "text": "they're"
+    },
+    {
+      "start": 993.02,
+      "end": 993.1,
+      "text": "not"
+    },
+    {
+      "start": 993.11,
+      "end": 993.35,
+      "text": "seeing"
+    },
+    {
+      "start": 993.35,
+      "end": 993.51,
+      "text": "in"
+    },
+    {
+      "start": 993.5,
+      "end": 993.58,
+      "text": "the"
+    },
+    {
+      "start": 993.58,
+      "end": 993.74,
+      "text": "Blue"
+    },
+    {
+      "start": 993.75,
+      "end": 993.99,
+      "text": "Sky"
+    },
+    {
+      "start": 993.99,
+      "end": 994.55,
+      "text": "app."
+    },
+    {
+      "start": 995.9,
+      "end": 996.14,
+      "text": "I"
+    },
+    {
+      "start": 996.14,
+      "end": 996.38,
+      "text": "wanna"
+    },
+    {
+      "start": 996.38,
+      "end": 996.62,
+      "text": "call"
+    },
+    {
+      "start": 996.63,
+      "end": 996.71,
+      "text": "out"
+    },
+    {
+      "start": 996.7,
+      "end": 996.86,
+      "text": "that"
+    },
+    {
+      "start": 996.87,
+      "end": 997.03,
+      "text": "I"
+    },
+    {
+      "start": 997.02,
+      "end": 997.18,
+      "text": "don't"
+    },
+    {
+      "start": 997.18,
+      "end": 997.26,
+      "text": "think"
+    },
+    {
+      "start": 997.26,
+      "end": 997.42,
+      "text": "that"
+    },
+    {
+      "start": 997.42,
+      "end": 997.5,
+      "text": "we"
+    },
+    {
+      "start": 997.5,
+      "end": 997.74,
+      "text": "need"
+    },
+    {
+      "start": 997.75,
+      "end": 997.91,
+      "text": "like"
+    },
+    {
+      "start": 997.9,
+      "end": 998.06,
+      "text": "an"
+    },
+    {
+      "start": 998.07,
+      "end": 998.39,
+      "text": "even"
+    },
+    {
+      "start": 998.38,
+      "end": 999.26,
+      "text": "distribution"
+    },
+    {
+      "start": 999.26,
+      "end": 999.82,
+      "text": "of"
+    },
+    {
+      "start": 999.82,
+      "end": 1000.38,
+      "text": "users"
+    },
+    {
+      "start": 1000.38,
+      "end": 1001.1,
+      "text": "across"
+    },
+    {
+      "start": 1001.11,
+      "end": 1001.75,
+      "text": "hosting"
+    },
+    {
+      "start": 1001.75,
+      "end": 1002.47,
+      "text": "infrastructure"
+    },
+    {
+      "start": 1002.46,
+      "end": 1002.7,
+      "text": "in"
+    },
+    {
+      "start": 1002.7,
+      "end": 1002.78,
+      "text": "the"
+    },
+    {
+      "start": 1002.78,
+      "end": 1003.02,
+      "text": "network"
+    },
+    {
+      "start": 1003.02,
+      "end": 1003.26,
+      "text": "in"
+    },
+    {
+      "start": 1003.26,
+      "end": 1003.5,
+      "text": "order"
+    },
+    {
+      "start": 1003.5,
+      "end": 1003.66,
+      "text": "to"
+    },
+    {
+      "start": 1003.66,
+      "end": 1003.98,
+      "text": "achieve"
+    },
+    {
+      "start": 1003.99,
+      "end": 1004.47,
+      "text": "this."
+    },
+    {
+      "start": 1004.54,
+      "end": 1004.7,
+      "text": "You"
+    },
+    {
+      "start": 1004.7,
+      "end": 1004.86,
+      "text": "can"
+    },
+    {
+      "start": 1004.87,
+      "end": 1005.43,
+      "text": "imagine"
+    },
+    {
+      "start": 1005.6,
+      "end": 1006.32,
+      "text": "5%"
+    },
+    {
+      "start": 1006.32,
+      "end": 1006.48,
+      "text": "of"
+    },
+    {
+      "start": 1006.48,
+      "end": 1006.56,
+      "text": "the"
+    },
+    {
+      "start": 1006.56,
+      "end": 1006.88,
+      "text": "network"
+    },
+    {
+      "start": 1006.88,
+      "end": 1007.2,
+      "text": "if"
+    },
+    {
+      "start": 1007.44,
+      "end": 1007.76,
+      "text": "even"
+    },
+    {
+      "start": 1007.76,
+      "end": 1007.92,
+      "text": "less"
+    },
+    {
+      "start": 1007.92,
+      "end": 1008.08,
+      "text": "than"
+    },
+    {
+      "start": 1008.08,
+      "end": 1008.32,
+      "text": "that."
+    },
+    {
+      "start": 1008.32,
+      "end": 1008.48,
+      "text": "If"
+    },
+    {
+      "start": 1008.48,
+      "end": 1008.64,
+      "text": "it's"
+    },
+    {
+      "start": 1008.64,
+      "end": 1008.8,
+      "text": "an"
+    },
+    {
+      "start": 1008.8,
+      "end": 1009.04,
+      "text": "important"
+    },
+    {
+      "start": 1009.04,
+      "end": 1009.6,
+      "text": "5%"
+    },
+    {
+      "start": 1009.6,
+      "end": 1009.76,
+      "text": "of"
+    },
+    {
+      "start": 1009.76,
+      "end": 1009.84,
+      "text": "the"
+    },
+    {
+      "start": 1009.84,
+      "end": 1010.4,
+      "text": "network,"
+    },
+    {
+      "start": 1010.4,
+      "end": 1010.48,
+      "text": "they"
+    },
+    {
+      "start": 1010.48,
+      "end": 1010.64,
+      "text": "would"
+    },
+    {
+      "start": 1010.64,
+      "end": 1010.8,
+      "text": "be"
+    },
+    {
+      "start": 1010.8,
+      "end": 1011.28,
+      "text": "disruptive"
+    },
+    {
+      "start": 1011.28,
+      "end": 1011.6,
+      "text": "enough"
+    },
+    {
+      "start": 1011.6,
+      "end": 1011.84,
+      "text": "that"
+    },
+    {
+      "start": 1011.84,
+      "end": 1012,
+      "text": "if"
+    },
+    {
+      "start": 1012,
+      "end": 1012.16,
+      "text": "you"
+    },
+    {
+      "start": 1012.16,
+      "end": 1012.32,
+      "text": "cut"
+    },
+    {
+      "start": 1012.32,
+      "end": 1012.48,
+      "text": "off"
+    },
+    {
+      "start": 1012.48,
+      "end": 1012.8,
+      "text": "access"
+    },
+    {
+      "start": 1012.8,
+      "end": 1012.96,
+      "text": "to"
+    },
+    {
+      "start": 1012.96,
+      "end": 1013.44,
+      "text": "them,"
+    },
+    {
+      "start": 1013.44,
+      "end": 1013.68,
+      "text": "people"
+    },
+    {
+      "start": 1013.68,
+      "end": 1014.24,
+      "text": "would"
+    },
+    {
+      "start": 1014.48,
+      "end": 1014.72,
+      "text": "be"
+    },
+    {
+      "start": 1014.72,
+      "end": 1015.04,
+      "text": "upset"
+    },
+    {
+      "start": 1015.04,
+      "end": 1015.2,
+      "text": "and"
+    },
+    {
+      "start": 1015.2,
+      "end": 1015.44,
+      "text": "leave"
+    },
+    {
+      "start": 1015.44,
+      "end": 1015.6,
+      "text": "the"
+    },
+    {
+      "start": 1015.6,
+      "end": 1015.76,
+      "text": "Blue"
+    },
+    {
+      "start": 1015.76,
+      "end": 1016,
+      "text": "Sky"
+    },
+    {
+      "start": 1016,
+      "end": 1016.48,
+      "text": "app."
+    },
+    {
+      "start": 1016.88,
+      "end": 1017.28,
+      "text": "This"
+    },
+    {
+      "start": 1017.28,
+      "end": 1018.96,
+      "text": "threat"
+    },
+    {
+      "start": 1017.75,
+      "end": 1018.07,
+      "text": "also"
+    },
+    {
+      "start": 1018.08,
+      "end": 1018.4,
+      "text": "becomes"
+    },
+    {
+      "start": 1018.39,
+      "end": 1018.79,
+      "text": "much"
+    },
+    {
+      "start": 1018.79,
+      "end": 1019.03,
+      "text": "less"
+    },
+    {
+      "start": 1019.03,
+      "end": 1019.59,
+      "text": "substantial"
+    },
+    {
+      "start": 1019.6,
+      "end": 1019.92,
+      "text": "if"
+    },
+    {
+      "start": 1019.91,
+      "end": 1020.07,
+      "text": "people"
+    },
+    {
+      "start": 1020.08,
+      "end": 1020.24,
+      "text": "can"
+    },
+    {
+      "start": 1020.24,
+      "end": 1020.48,
+      "text": "just"
+    },
+    {
+      "start": 1020.48,
+      "end": 1020.64,
+      "text": "go"
+    },
+    {
+      "start": 1020.63,
+      "end": 1020.87,
+      "text": "to"
+    },
+    {
+      "start": 1020.88,
+      "end": 1021.2,
+      "text": "another"
+    },
+    {
+      "start": 1021.2,
+      "end": 1021.44,
+      "text": "app"
+    },
+    {
+      "start": 1021.43,
+      "end": 1021.67,
+      "text": "that"
+    },
+    {
+      "start": 1021.67,
+      "end": 1021.99,
+      "text": "is"
+    },
+    {
+      "start": 1022,
+      "end": 1022.64,
+      "text": "indexing"
+    },
+    {
+      "start": 1022.63,
+      "end": 1022.95,
+      "text": "both"
+    },
+    {
+      "start": 1022.96,
+      "end": 1023.28,
+      "text": "Blue"
+    },
+    {
+      "start": 1023.27,
+      "end": 1023.51,
+      "text": "Sky"
+    },
+    {
+      "start": 1023.51,
+      "end": 1024.15,
+      "text": "content"
+    },
+    {
+      "start": 1024.47,
+      "end": 1024.95,
+      "text": "content"
+    },
+    {
+      "start": 1024.95,
+      "end": 1025.35,
+      "text": "from"
+    },
+    {
+      "start": 1027.04,
+      "end": 1027.36,
+      "text": "having"
+    },
+    {
+      "start": 1028.47,
+      "end": 1029.11,
+      "text": "network"
+    },
+    {
+      "start": 1030.23,
+      "end": 1030.55,
+      "text": "threat."
+    },
+    {
+      "start": 1032.76,
+      "end": 1033.16,
+      "text": "Another"
+    },
+    {
+      "start": 1033.56,
+      "end": 1033.8,
+      "text": "Blue"
+    },
+    {
+      "start": 1033.8,
+      "end": 1034.04,
+      "text": "Sky"
+    },
+    {
+      "start": 1034.04,
+      "end": 1034.44,
+      "text": "messing"
+    },
+    {
+      "start": 1034.44,
+      "end": 1034.6,
+      "text": "with"
+    },
+    {
+      "start": 1036.28,
+      "end": 1036.84,
+      "text": "are"
+    },
+    {
+      "start": 1037.72,
+      "end": 1037.88,
+      "text": "from"
+    },
+    {
+      "start": 1038.44,
+      "end": 1038.68,
+      "text": "between"
+    },
+    {
+      "start": 1040.04,
+      "end": 1040.28,
+      "text": "de"
+    },
+    {
+      "start": 1040.28,
+      "end": 1040.84,
+      "text": "platforming"
+    },
+    {
+      "start": 1041.56,
+      "end": 1041.72,
+      "text": "if"
+    },
+    {
+      "start": 1041.72,
+      "end": 1041.88,
+      "text": "we"
+    },
+    {
+      "start": 1042.04,
+      "end": 1042.2,
+      "text": "have"
+    },
+    {
+      "start": 1042.2,
+      "end": 1042.44,
+      "text": "Just"
+    },
+    {
+      "start": 1042.44,
+      "end": 1043.08,
+      "text": "Cause,"
+    },
+    {
+      "start": 1043.96,
+      "end": 1044.52,
+      "text": "users"
+    },
+    {
+      "start": 1044.52,
+      "end": 1044.76,
+      "text": "from"
+    },
+    {
+      "start": 1044.76,
+      "end": 1045.16,
+      "text": "using"
+    },
+    {
+      "start": 1045.56,
+      "end": 1045.8,
+      "text": "apps"
+    },
+    {
+      "start": 1045.8,
+      "end": 1046.04,
+      "text": "or"
+    },
+    {
+      "start": 1046.04,
+      "end": 1046.44,
+      "text": "competitors."
+    },
+    {
+      "start": 1047.26,
+      "end": 1047.42,
+      "text": "that"
+    },
+    {
+      "start": 1047.49,
+      "end": 1047.65,
+      "text": "need"
+    },
+    {
+      "start": 1047.97,
+      "end": 1048.13,
+      "text": "bay"
+    },
+    {
+      "start": 1048.46,
+      "end": 1048.78,
+      "text": "need"
+    },
+    {
+      "start": 1048.78,
+      "end": 1048.94,
+      "text": "to"
+    },
+    {
+      "start": 1048.93,
+      "end": 1049.17,
+      "text": "prevent"
+    },
+    {
+      "start": 1049.17,
+      "end": 1049.33,
+      "text": "this"
+    },
+    {
+      "start": 1049.34,
+      "end": 1049.58,
+      "text": "are"
+    },
+    {
+      "start": 1049.58,
+      "end": 1050.06,
+      "text": "basically"
+    },
+    {
+      "start": 1050.06,
+      "end": 1050.62,
+      "text": "account"
+    },
+    {
+      "start": 1050.62,
+      "end": 1051.26,
+      "text": "recovery"
+    },
+    {
+      "start": 1051.26,
+      "end": 1051.58,
+      "text": "or"
+    },
+    {
+      "start": 1051.58,
+      "end": 1051.98,
+      "text": "export"
+    },
+    {
+      "start": 1051.97,
+      "end": 1052.61,
+      "text": "tools."
+    },
+    {
+      "start": 1052.7,
+      "end": 1053.02,
+      "text": "So,"
+    },
+    {
+      "start": 1053.02,
+      "end": 1053.42,
+      "text": "backups"
+    },
+    {
+      "start": 1053.41,
+      "end": 1053.57,
+      "text": "of"
+    },
+    {
+      "start": 1053.58,
+      "end": 1054.3,
+      "text": "repositories"
+    },
+    {
+      "start": 1054.3,
+      "end": 1054.54,
+      "text": "if"
+    },
+    {
+      "start": 1054.54,
+      "end": 1054.78,
+      "text": "Blue"
+    },
+    {
+      "start": 1054.78,
+      "end": 1054.94,
+      "text": "Sky"
+    },
+    {
+      "start": 1054.93,
+      "end": 1055.17,
+      "text": "is"
+    },
+    {
+      "start": 1055.17,
+      "end": 1055.49,
+      "text": "refusing"
+    },
+    {
+      "start": 1055.49,
+      "end": 1055.73,
+      "text": "to"
+    },
+    {
+      "start": 1055.73,
+      "end": 1056.05,
+      "text": "serve"
+    },
+    {
+      "start": 1056.06,
+      "end": 1056.38,
+      "text": "your"
+    },
+    {
+      "start": 1056.38,
+      "end": 1057.02,
+      "text": "repository"
+    },
+    {
+      "start": 1057.02,
+      "end": 1057.18,
+      "text": "to"
+    },
+    {
+      "start": 1057.17,
+      "end": 1057.65,
+      "text": "you,"
+    },
+    {
+      "start": 1057.82,
+      "end": 1058.14,
+      "text": "user"
+    },
+    {
+      "start": 1058.13,
+      "end": 1058.37,
+      "text": "held"
+    },
+    {
+      "start": 1058.38,
+      "end": 1058.94,
+      "text": "recovery"
+    },
+    {
+      "start": 1058.93,
+      "end": 1059.17,
+      "text": "keys"
+    },
+    {
+      "start": 1059.17,
+      "end": 1059.41,
+      "text": "in"
+    },
+    {
+      "start": 1059.41,
+      "end": 1059.57,
+      "text": "case"
+    },
+    {
+      "start": 1059.58,
+      "end": 1059.9,
+      "text": "Blue"
+    },
+    {
+      "start": 1059.89,
+      "end": 1060.13,
+      "text": "Sky"
+    },
+    {
+      "start": 1060.13,
+      "end": 1060.29,
+      "text": "is"
+    },
+    {
+      "start": 1060.3,
+      "end": 1060.7,
+      "text": "refusing"
+    },
+    {
+      "start": 1060.7,
+      "end": 1060.78,
+      "text": "to"
+    },
+    {
+      "start": 1060.78,
+      "end": 1061.26,
+      "text": "sign"
+    },
+    {
+      "start": 1061.85,
+      "end": 1062.25,
+      "text": "account"
+    },
+    {
+      "start": 1062.25,
+      "end": 1062.73,
+      "text": "migration"
+    },
+    {
+      "start": 1062.73,
+      "end": 1063.21,
+      "text": "operations"
+    },
+    {
+      "start": 1063.21,
+      "end": 1063.45,
+      "text": "on"
+    },
+    {
+      "start": 1063.45,
+      "end": 1063.69,
+      "text": "your"
+    },
+    {
+      "start": 1063.69,
+      "end": 1064.09,
+      "text": "behalf,"
+    },
+    {
+      "start": 1064.09,
+      "end": 1064.41,
+      "text": "and"
+    },
+    {
+      "start": 1064.41,
+      "end": 1064.57,
+      "text": "then"
+    },
+    {
+      "start": 1064.57,
+      "end": 1064.73,
+      "text": "just"
+    },
+    {
+      "start": 1064.73,
+      "end": 1064.97,
+      "text": "a"
+    },
+    {
+      "start": 1064.97,
+      "end": 1065.29,
+      "text": "place"
+    },
+    {
+      "start": 1065.29,
+      "end": 1065.45,
+      "text": "to"
+    },
+    {
+      "start": 1065.45,
+      "end": 1065.85,
+      "text": "go."
+    },
+    {
+      "start": 1065.85,
+      "end": 1066.25,
+      "text": "Non"
+    },
+    {
+      "start": 1066.25,
+      "end": 1066.49,
+      "text": "Blue"
+    },
+    {
+      "start": 1066.49,
+      "end": 1066.73,
+      "text": "Sky"
+    },
+    {
+      "start": 1066.73,
+      "end": 1067.13,
+      "text": "PDS"
+    },
+    {
+      "start": 1067.13,
+      "end": 1067.29,
+      "text": "is"
+    },
+    {
+      "start": 1067.29,
+      "end": 1067.53,
+      "text": "running"
+    },
+    {
+      "start": 1067.53,
+      "end": 1067.61,
+      "text": "in"
+    },
+    {
+      "start": 1067.61,
+      "end": 1067.77,
+      "text": "the"
+    },
+    {
+      "start": 1067.77,
+      "end": 1068.01,
+      "text": "network"
+    },
+    {
+      "start": 1068.01,
+      "end": 1068.25,
+      "text": "that"
+    },
+    {
+      "start": 1068.25,
+      "end": 1068.41,
+      "text": "you"
+    },
+    {
+      "start": 1068.41,
+      "end": 1068.57,
+      "text": "can"
+    },
+    {
+      "start": 1068.57,
+      "end": 1068.89,
+      "text": "migrate"
+    },
+    {
+      "start": 1068.89,
+      "end": 1069.45,
+      "text": "to."
+    },
+    {
+      "start": 1071.13,
+      "end": 1071.37,
+      "text": "And"
+    },
+    {
+      "start": 1071.37,
+      "end": 1071.53,
+      "text": "then"
+    },
+    {
+      "start": 1071.53,
+      "end": 1071.77,
+      "text": "the"
+    },
+    {
+      "start": 1071.77,
+      "end": 1072.09,
+      "text": "final"
+    },
+    {
+      "start": 1072.09,
+      "end": 1072.33,
+      "text": "threat"
+    },
+    {
+      "start": 1072.33,
+      "end": 1072.65,
+      "text": "is"
+    },
+    {
+      "start": 1072.65,
+      "end": 1073.21,
+      "text": "Blue"
+    },
+    {
+      "start": 1073.21,
+      "end": 1073.53,
+      "text": "Sky"
+    },
+    {
+      "start": 1073.53,
+      "end": 1073.85,
+      "text": "just"
+    },
+    {
+      "start": 1073.85,
+      "end": 1074.25,
+      "text": "losing"
+    },
+    {
+      "start": 1074.25,
+      "end": 1074.57,
+      "text": "access"
+    },
+    {
+      "start": 1074.57,
+      "end": 1074.73,
+      "text": "to"
+    },
+    {
+      "start": 1074.73,
+      "end": 1075.45,
+      "text": "accounts."
+    },
+    {
+      "start": 1075.77,
+      "end": 1076.01,
+      "text": "This"
+    },
+    {
+      "start": 1076.01,
+      "end": 1076.25,
+      "text": "may"
+    },
+    {
+      "start": 1076.25,
+      "end": 1076.73,
+      "text": "be"
+    },
+    {
+      "start": 1077.73,
+      "end": 1077.97,
+      "text": "sort"
+    },
+    {
+      "start": 1077.97,
+      "end": 1078.13,
+      "text": "of"
+    },
+    {
+      "start": 1078.13,
+      "end": 1078.37,
+      "text": "out"
+    },
+    {
+      "start": 1078.38,
+      "end": 1078.54,
+      "text": "of"
+    },
+    {
+      "start": 1078.54,
+      "end": 1078.86,
+      "text": "ill"
+    },
+    {
+      "start": 1078.86,
+      "end": 1079.26,
+      "text": "intentions"
+    },
+    {
+      "start": 1079.26,
+      "end": 1079.5,
+      "text": "or"
+    },
+    {
+      "start": 1079.49,
+      "end": 1079.73,
+      "text": "this"
+    },
+    {
+      "start": 1079.73,
+      "end": 1079.89,
+      "text": "may"
+    },
+    {
+      "start": 1079.89,
+      "end": 1080.05,
+      "text": "be"
+    },
+    {
+      "start": 1080.06,
+      "end": 1080.62,
+      "text": "external"
+    },
+    {
+      "start": 1080.62,
+      "end": 1081.42,
+      "text": "forces."
+    },
+    {
+      "start": 1081.49,
+      "end": 1081.65,
+      "text": "So"
+    },
+    {
+      "start": 1081.65,
+      "end": 1081.97,
+      "text": "going"
+    },
+    {
+      "start": 1081.97,
+      "end": 1082.13,
+      "text": "out"
+    },
+    {
+      "start": 1082.13,
+      "end": 1082.61,
+      "text": "of"
+    },
+    {
+      "start": 1082.62,
+      "end": 1083.42,
+      "text": "business,"
+    },
+    {
+      "start": 1083.41,
+      "end": 1083.57,
+      "text": "you"
+    },
+    {
+      "start": 1083.58,
+      "end": 1083.82,
+      "text": "know,"
+    },
+    {
+      "start": 1083.82,
+      "end": 1083.98,
+      "text": "a"
+    },
+    {
+      "start": 1083.97,
+      "end": 1084.13,
+      "text": "data"
+    },
+    {
+      "start": 1084.13,
+      "end": 1084.45,
+      "text": "center"
+    },
+    {
+      "start": 1084.46,
+      "end": 1084.7,
+      "text": "blowing"
+    },
+    {
+      "start": 1084.7,
+      "end": 1085.18,
+      "text": "up,"
+    },
+    {
+      "start": 1085.17,
+      "end": 1085.49,
+      "text": "legal"
+    },
+    {
+      "start": 1085.49,
+      "end": 1085.97,
+      "text": "action,"
+    },
+    {
+      "start": 1085.97,
+      "end": 1086.37,
+      "text": "servers"
+    },
+    {
+      "start": 1086.38,
+      "end": 1086.7,
+      "text": "getting"
+    },
+    {
+      "start": 1086.7,
+      "end": 1087.26,
+      "text": "seized,"
+    },
+    {
+      "start": 1087.26,
+      "end": 1087.5,
+      "text": "something"
+    },
+    {
+      "start": 1087.49,
+      "end": 1087.65,
+      "text": "like"
+    },
+    {
+      "start": 1087.65,
+      "end": 1088.13,
+      "text": "that."
+    },
+    {
+      "start": 1088.38,
+      "end": 1088.46,
+      "text": "I"
+    },
+    {
+      "start": 1088.46,
+      "end": 1088.62,
+      "text": "would"
+    },
+    {
+      "start": 1088.62,
+      "end": 1088.86,
+      "text": "expect"
+    },
+    {
+      "start": 1088.86,
+      "end": 1089.1,
+      "text": "in"
+    },
+    {
+      "start": 1089.1,
+      "end": 1089.34,
+      "text": "most"
+    },
+    {
+      "start": 1089.34,
+      "end": 1089.9,
+      "text": "cases,"
+    },
+    {
+      "start": 1089.97,
+      "end": 1090.21,
+      "text": "Sky"
+    },
+    {
+      "start": 1090.21,
+      "end": 1090.45,
+      "text": "should"
+    },
+    {
+      "start": 1090.46,
+      "end": 1090.54,
+      "text": "be"
+    },
+    {
+      "start": 1090.54,
+      "end": 1090.7,
+      "text": "able"
+    },
+    {
+      "start": 1090.7,
+      "end": 1090.78,
+      "text": "to"
+    },
+    {
+      "start": 1090.78,
+      "end": 1091.82,
+      "text": "help"
+    },
+    {
+      "start": 1090.98,
+      "end": 1091.3,
+      "text": "ease"
+    },
+    {
+      "start": 1091.3,
+      "end": 1091.46,
+      "text": "this"
+    },
+    {
+      "start": 1091.46,
+      "end": 1092.1,
+      "text": "transition."
+    },
+    {
+      "start": 1092.1,
+      "end": 1092.34,
+      "text": "For"
+    },
+    {
+      "start": 1092.34,
+      "end": 1092.66,
+      "text": "instance,"
+    },
+    {
+      "start": 1092.66,
+      "end": 1092.9,
+      "text": "like"
+    },
+    {
+      "start": 1092.9,
+      "end": 1093.14,
+      "text": "the"
+    },
+    {
+      "start": 1093.14,
+      "end": 1093.3,
+      "text": "most"
+    },
+    {
+      "start": 1093.3,
+      "end": 1093.62,
+      "text": "likely"
+    },
+    {
+      "start": 1093.62,
+      "end": 1093.78,
+      "text": "one"
+    },
+    {
+      "start": 1093.78,
+      "end": 1093.86,
+      "text": "of"
+    },
+    {
+      "start": 1093.86,
+      "end": 1094.02,
+      "text": "these"
+    },
+    {
+      "start": 1094.02,
+      "end": 1094.18,
+      "text": "is"
+    },
+    {
+      "start": 1094.18,
+      "end": 1094.42,
+      "text": "probably"
+    },
+    {
+      "start": 1094.42,
+      "end": 1094.74,
+      "text": "Blue"
+    },
+    {
+      "start": 1094.74,
+      "end": 1094.98,
+      "text": "Sky"
+    },
+    {
+      "start": 1094.98,
+      "end": 1095.22,
+      "text": "going"
+    },
+    {
+      "start": 1095.22,
+      "end": 1095.3,
+      "text": "out"
+    },
+    {
+      "start": 1095.3,
+      "end": 1095.46,
+      "text": "of"
+    },
+    {
+      "start": 1095.46,
+      "end": 1096.02,
+      "text": "business."
+    },
+    {
+      "start": 1096.18,
+      "end": 1096.42,
+      "text": "And"
+    },
+    {
+      "start": 1096.42,
+      "end": 1096.74,
+      "text": "we"
+    },
+    {
+      "start": 1096.74,
+      "end": 1096.9,
+      "text": "should"
+    },
+    {
+      "start": 1096.9,
+      "end": 1097.06,
+      "text": "be"
+    },
+    {
+      "start": 1097.06,
+      "end": 1097.14,
+      "text": "able"
+    },
+    {
+      "start": 1097.14,
+      "end": 1097.3,
+      "text": "to"
+    },
+    {
+      "start": 1097.3,
+      "end": 1097.46,
+      "text": "help"
+    },
+    {
+      "start": 1097.46,
+      "end": 1097.7,
+      "text": "ease"
+    },
+    {
+      "start": 1097.7,
+      "end": 1097.86,
+      "text": "the"
+    },
+    {
+      "start": 1097.86,
+      "end": 1098.42,
+      "text": "transition"
+    },
+    {
+      "start": 1098.42,
+      "end": 1098.74,
+      "text": "if"
+    },
+    {
+      "start": 1098.74,
+      "end": 1098.9,
+      "text": "that"
+    },
+    {
+      "start": 1098.9,
+      "end": 1099.06,
+      "text": "were"
+    },
+    {
+      "start": 1099.06,
+      "end": 1099.14,
+      "text": "the"
+    },
+    {
+      "start": 1099.14,
+      "end": 1099.3,
+      "text": "case"
+    },
+    {
+      "start": 1099.3,
+      "end": 1099.7,
+      "text": "even"
+    },
+    {
+      "start": 1099.7,
+      "end": 1099.78,
+      "text": "if"
+    },
+    {
+      "start": 1099.78,
+      "end": 1099.94,
+      "text": "we"
+    },
+    {
+      "start": 1099.94,
+      "end": 1100.5,
+      "text": "stop"
+    },
+    {
+      "start": 1100.5,
+      "end": 1100.98,
+      "text": "providing"
+    },
+    {
+      "start": 1100.98,
+      "end": 1101.54,
+      "text": "PDS"
+    },
+    {
+      "start": 1101.54,
+      "end": 1102.02,
+      "text": "services."
+    },
+    {
+      "start": 1102.02,
+      "end": 1102.18,
+      "text": "It's"
+    },
+    {
+      "start": 1102.18,
+      "end": 1102.42,
+      "text": "very"
+    },
+    {
+      "start": 1102.42,
+      "end": 1102.66,
+      "text": "cheap"
+    },
+    {
+      "start": 1102.66,
+      "end": 1102.82,
+      "text": "for"
+    },
+    {
+      "start": 1102.82,
+      "end": 1102.98,
+      "text": "us"
+    },
+    {
+      "start": 1102.98,
+      "end": 1103.06,
+      "text": "to"
+    },
+    {
+      "start": 1103.06,
+      "end": 1103.3,
+      "text": "keep"
+    },
+    {
+      "start": 1103.3,
+      "end": 1103.46,
+      "text": "some"
+    },
+    {
+      "start": 1103.46,
+      "end": 1104.02,
+      "text": "PDS's"
+    },
+    {
+      "start": 1104.02,
+      "end": 1104.34,
+      "text": "online"
+    },
+    {
+      "start": 1104.34,
+      "end": 1104.58,
+      "text": "and"
+    },
+    {
+      "start": 1104.58,
+      "end": 1104.9,
+      "text": "rotation"
+    },
+    {
+      "start": 1104.9,
+      "end": 1105.22,
+      "text": "keys"
+    },
+    {
+      "start": 1105.22,
+      "end": 1105.46,
+      "text": "as"
+    },
+    {
+      "start": 1105.46,
+      "end": 1105.62,
+      "text": "people"
+    },
+    {
+      "start": 1105.62,
+      "end": 1105.86,
+      "text": "move"
+    },
+    {
+      "start": 1105.86,
+      "end": 1106.02,
+      "text": "off."
+    },
+    {
+      "start": 1106.46,
+      "end": 1106.7,
+      "text": "In"
+    },
+    {
+      "start": 1106.71,
+      "end": 1107.11,
+      "text": "extreme"
+    },
+    {
+      "start": 1107.11,
+      "end": 1107.43,
+      "text": "cases"
+    },
+    {
+      "start": 1107.42,
+      "end": 1107.66,
+      "text": "where"
+    },
+    {
+      "start": 1107.66,
+      "end": 1107.9,
+      "text": "Blue"
+    },
+    {
+      "start": 1107.9,
+      "end": 1108.22,
+      "text": "Sky"
+    },
+    {
+      "start": 1108.22,
+      "end": 1108.54,
+      "text": "is"
+    },
+    {
+      "start": 1108.55,
+      "end": 1109.03,
+      "text": "refusing"
+    },
+    {
+      "start": 1109.03,
+      "end": 1109.19,
+      "text": "to"
+    },
+    {
+      "start": 1109.18,
+      "end": 1109.34,
+      "text": "do"
+    },
+    {
+      "start": 1109.35,
+      "end": 1109.43,
+      "text": "that"
+    },
+    {
+      "start": 1109.42,
+      "end": 1109.74,
+      "text": "or"
+    },
+    {
+      "start": 1109.74,
+      "end": 1110.22,
+      "text": "unable"
+    },
+    {
+      "start": 1110.22,
+      "end": 1110.46,
+      "text": "to"
+    },
+    {
+      "start": 1110.46,
+      "end": 1110.54,
+      "text": "do"
+    },
+    {
+      "start": 1110.55,
+      "end": 1110.71,
+      "text": "it"
+    },
+    {
+      "start": 1110.71,
+      "end": 1110.87,
+      "text": "for"
+    },
+    {
+      "start": 1110.87,
+      "end": 1111.03,
+      "text": "some"
+    },
+    {
+      "start": 1111.03,
+      "end": 1111.51,
+      "text": "reason,"
+    },
+    {
+      "start": 1111.51,
+      "end": 1111.67,
+      "text": "we"
+    },
+    {
+      "start": 1111.66,
+      "end": 1112.06,
+      "text": "essentially"
+    },
+    {
+      "start": 1112.07,
+      "end": 1112.47,
+      "text": "need"
+    },
+    {
+      "start": 1112.46,
+      "end": 1112.7,
+      "text": "the"
+    },
+    {
+      "start": 1112.87,
+      "end": 1113.11,
+      "text": "what"
+    },
+    {
+      "start": 1113.11,
+      "end": 1113.27,
+      "text": "we"
+    },
+    {
+      "start": 1113.27,
+      "end": 1113.43,
+      "text": "got"
+    },
+    {
+      "start": 1113.42,
+      "end": 1113.58,
+      "text": "from"
+    },
+    {
+      "start": 1113.59,
+      "end": 1113.67,
+      "text": "the"
+    },
+    {
+      "start": 1113.66,
+      "end": 1113.9,
+      "text": "last"
+    },
+    {
+      "start": 1113.9,
+      "end": 1114.14,
+      "text": "threat"
+    },
+    {
+      "start": 1114.14,
+      "end": 1114.38,
+      "text": "which"
+    },
+    {
+      "start": 1114.38,
+      "end": 1114.78,
+      "text": "is"
+    },
+    {
+      "start": 1114.79,
+      "end": 1115.19,
+      "text": "backups"
+    },
+    {
+      "start": 1115.18,
+      "end": 1115.42,
+      "text": "of"
+    },
+    {
+      "start": 1115.42,
+      "end": 1116.22,
+      "text": "repositories"
+    },
+    {
+      "start": 1116.22,
+      "end": 1116.46,
+      "text": "and"
+    },
+    {
+      "start": 1116.46,
+      "end": 1116.86,
+      "text": "user"
+    },
+    {
+      "start": 1116.87,
+      "end": 1117.19,
+      "text": "held"
+    },
+    {
+      "start": 1117.18,
+      "end": 1117.74,
+      "text": "recovery"
+    },
+    {
+      "start": 1117.74,
+      "end": 1118.06,
+      "text": "keys."
+    },
+    {
+      "start": 1120.16,
+      "end": 1120.64,
+      "text": "So,"
+    },
+    {
+      "start": 1120.64,
+      "end": 1121.04,
+      "text": "pulling"
+    },
+    {
+      "start": 1121.04,
+      "end": 1121.28,
+      "text": "out"
+    },
+    {
+      "start": 1121.28,
+      "end": 1121.52,
+      "text": "the"
+    },
+    {
+      "start": 1121.52,
+      "end": 1121.84,
+      "text": "things"
+    },
+    {
+      "start": 1121.84,
+      "end": 1122.16,
+      "text": "that"
+    },
+    {
+      "start": 1122.16,
+      "end": 1122.48,
+      "text": "we"
+    },
+    {
+      "start": 1122.48,
+      "end": 1122.88,
+      "text": "found"
+    },
+    {
+      "start": 1122.88,
+      "end": 1123.04,
+      "text": "that"
+    },
+    {
+      "start": 1123.04,
+      "end": 1123.12,
+      "text": "we"
+    },
+    {
+      "start": 1123.12,
+      "end": 1123.36,
+      "text": "needed"
+    },
+    {
+      "start": 1123.36,
+      "end": 1123.6,
+      "text": "for"
+    },
+    {
+      "start": 1123.6,
+      "end": 1123.76,
+      "text": "each"
+    },
+    {
+      "start": 1123.76,
+      "end": 1123.84,
+      "text": "of"
+    },
+    {
+      "start": 1123.84,
+      "end": 1124.08,
+      "text": "these,"
+    },
+    {
+      "start": 1124.08,
+      "end": 1124.32,
+      "text": "it's"
+    },
+    {
+      "start": 1124.32,
+      "end": 1124.8,
+      "text": "basically"
+    },
+    {
+      "start": 1124.8,
+      "end": 1125.04,
+      "text": "app"
+    },
+    {
+      "start": 1125.04,
+      "end": 1125.28,
+      "text": "view"
+    },
+    {
+      "start": 1125.28,
+      "end": 1126.16,
+      "text": "implementation"
+    },
+    {
+      "start": 1126.16,
+      "end": 1126.64,
+      "text": "and"
+    },
+    {
+      "start": 1126.64,
+      "end": 1127.12,
+      "text": "sync"
+    },
+    {
+      "start": 1127.12,
+      "end": 1127.84,
+      "text": "tooling."
+    },
+    {
+      "start": 1130.64,
+      "end": 1130.96,
+      "text": "Nice."
+    },
+    {
+      "start": 1131.29,
+      "end": 1131.69,
+      "text": "More"
+    },
+    {
+      "start": 1131.68,
+      "end": 1132.08,
+      "text": "users"
+    },
+    {
+      "start": 1132.09,
+      "end": 1132.49,
+      "text": "on"
+    },
+    {
+      "start": 1132.48,
+      "end": 1132.72,
+      "text": "non"
+    },
+    {
+      "start": 1132.73,
+      "end": 1132.97,
+      "text": "blue"
+    },
+    {
+      "start": 1132.97,
+      "end": 1133.21,
+      "text": "sky"
+    },
+    {
+      "start": 1133.21,
+      "end": 1133.93,
+      "text": "PDSs,"
+    },
+    {
+      "start": 1133.92,
+      "end": 1134.08,
+      "text": "so"
+    },
+    {
+      "start": 1134.09,
+      "end": 1134.25,
+      "text": "a"
+    },
+    {
+      "start": 1134.24,
+      "end": 1134.32,
+      "text": "more"
+    },
+    {
+      "start": 1134.33,
+      "end": 1134.73,
+      "text": "diverse"
+    },
+    {
+      "start": 1134.73,
+      "end": 1135.05,
+      "text": "open"
+    },
+    {
+      "start": 1135.05,
+      "end": 1135.29,
+      "text": "data"
+    },
+    {
+      "start": 1135.29,
+      "end": 1135.69,
+      "text": "hosting"
+    },
+    {
+      "start": 1135.68,
+      "end": 1136.32,
+      "text": "layer."
+    },
+    {
+      "start": 1136.88,
+      "end": 1137.28,
+      "text": "Consumer"
+    },
+    {
+      "start": 1137.29,
+      "end": 1137.69,
+      "text": "key"
+    },
+    {
+      "start": 1137.68,
+      "end": 1138.16,
+      "text": "management"
+    },
+    {
+      "start": 1138.16,
+      "end": 1138.4,
+      "text": "and"
+    },
+    {
+      "start": 1138.4,
+      "end": 1138.88,
+      "text": "recovery"
+    },
+    {
+      "start": 1138.88,
+      "end": 1139.2,
+      "text": "tools"
+    },
+    {
+      "start": 1139.21,
+      "end": 1139.93,
+      "text": "putting"
+    },
+    {
+      "start": 1140.01,
+      "end": 1140.65,
+      "text": "rotation"
+    },
+    {
+      "start": 1140.64,
+      "end": 1140.96,
+      "text": "keys"
+    },
+    {
+      "start": 1140.97,
+      "end": 1141.13,
+      "text": "in"
+    },
+    {
+      "start": 1141.13,
+      "end": 1141.21,
+      "text": "the"
+    },
+    {
+      "start": 1141.21,
+      "end": 1141.37,
+      "text": "hands"
+    },
+    {
+      "start": 1141.37,
+      "end": 1141.53,
+      "text": "of"
+    },
+    {
+      "start": 1141.53,
+      "end": 1142.17,
+      "text": "users."
+    },
+    {
+      "start": 1142.4,
+      "end": 1142.72,
+      "text": "Other"
+    },
+    {
+      "start": 1142.73,
+      "end": 1142.97,
+      "text": "data"
+    },
+    {
+      "start": 1142.97,
+      "end": 1143.37,
+      "text": "sources"
+    },
+    {
+      "start": 1143.37,
+      "end": 1143.69,
+      "text": "and"
+    },
+    {
+      "start": 1143.68,
+      "end": 1144.08,
+      "text": "backups"
+    },
+    {
+      "start": 1144.09,
+      "end": 1144.33,
+      "text": "for"
+    },
+    {
+      "start": 1144.33,
+      "end": 1145.13,
+      "text": "repositories,"
+    },
+    {
+      "start": 1145.31,
+      "end": 1145.63,
+      "text": "and"
+    },
+    {
+      "start": 1145.63,
+      "end": 1145.79,
+      "text": "then"
+    },
+    {
+      "start": 1145.79,
+      "end": 1145.95,
+      "text": "a"
+    },
+    {
+      "start": 1145.95,
+      "end": 1146.35,
+      "text": "thriving"
+    },
+    {
+      "start": 1146.35,
+      "end": 1146.91,
+      "text": "ecosystem"
+    },
+    {
+      "start": 1146.91,
+      "end": 1147.39,
+      "text": "built"
+    },
+    {
+      "start": 1147.39,
+      "end": 1147.63,
+      "text": "on"
+    },
+    {
+      "start": 1147.63,
+      "end": 1147.95,
+      "text": "open"
+    },
+    {
+      "start": 1147.95,
+      "end": 1148.59,
+      "text": "data."
+    },
+    {
+      "start": 1148.67,
+      "end": 1148.91,
+      "text": "So,"
+    },
+    {
+      "start": 1148.91,
+      "end": 1148.99,
+      "text": "I"
+    },
+    {
+      "start": 1148.99,
+      "end": 1149.15,
+      "text": "wanna"
+    },
+    {
+      "start": 1149.15,
+      "end": 1149.39,
+      "text": "walk"
+    },
+    {
+      "start": 1149.39,
+      "end": 1149.63,
+      "text": "through"
+    },
+    {
+      "start": 1149.63,
+      "end": 1149.87,
+      "text": "each"
+    },
+    {
+      "start": 1149.87,
+      "end": 1150.03,
+      "text": "one"
+    },
+    {
+      "start": 1150.03,
+      "end": 1150.11,
+      "text": "of"
+    },
+    {
+      "start": 1150.11,
+      "end": 1150.27,
+      "text": "these"
+    },
+    {
+      "start": 1150.27,
+      "end": 1150.51,
+      "text": "and"
+    },
+    {
+      "start": 1150.51,
+      "end": 1150.67,
+      "text": "talk"
+    },
+    {
+      "start": 1150.67,
+      "end": 1150.91,
+      "text": "about"
+    },
+    {
+      "start": 1150.91,
+      "end": 1151.07,
+      "text": "what"
+    },
+    {
+      "start": 1151.07,
+      "end": 1151.23,
+      "text": "the"
+    },
+    {
+      "start": 1151.23,
+      "end": 1151.39,
+      "text": "Blue"
+    },
+    {
+      "start": 1151.39,
+      "end": 1151.63,
+      "text": "Sky"
+    },
+    {
+      "start": 1151.63,
+      "end": 1151.87,
+      "text": "team"
+    },
+    {
+      "start": 1151.87,
+      "end": 1152.03,
+      "text": "can"
+    },
+    {
+      "start": 1152.03,
+      "end": 1152.27,
+      "text": "do,"
+    },
+    {
+      "start": 1152.27,
+      "end": 1152.43,
+      "text": "what"
+    },
+    {
+      "start": 1152.43,
+      "end": 1152.51,
+      "text": "we"
+    },
+    {
+      "start": 1152.51,
+      "end": 1152.75,
+      "text": "are"
+    },
+    {
+      "start": 1152.75,
+      "end": 1153.15,
+      "text": "doing,"
+    },
+    {
+      "start": 1153.15,
+      "end": 1153.23,
+      "text": "and"
+    },
+    {
+      "start": 1153.23,
+      "end": 1153.39,
+      "text": "then"
+    },
+    {
+      "start": 1153.39,
+      "end": 1153.55,
+      "text": "what"
+    },
+    {
+      "start": 1153.55,
+      "end": 1153.79,
+      "text": "folks"
+    },
+    {
+      "start": 1153.79,
+      "end": 1153.95,
+      "text": "in"
+    },
+    {
+      "start": 1153.95,
+      "end": 1154.35,
+      "text": "the"
+    },
+    {
+      "start": 1154.35,
+      "end": 1154.91,
+      "text": "ecosystem"
+    },
+    {
+      "start": 1154.91,
+      "end": 1155.15,
+      "text": "can"
+    },
+    {
+      "start": 1155.15,
+      "end": 1155.31,
+      "text": "do"
+    },
+    {
+      "start": 1155.31,
+      "end": 1155.55,
+      "text": "if"
+    },
+    {
+      "start": 1155.55,
+      "end": 1155.71,
+      "text": "you're"
+    },
+    {
+      "start": 1155.71,
+      "end": 1155.95,
+      "text": "concerned"
+    },
+    {
+      "start": 1155.95,
+      "end": 1156.19,
+      "text": "about"
+    },
+    {
+      "start": 1156.19,
+      "end": 1156.43,
+      "text": "these"
+    },
+    {
+      "start": 1156.43,
+      "end": 1156.83,
+      "text": "particular"
+    },
+    {
+      "start": 1156.83,
+      "end": 1157.23,
+      "text": "threats."
+    },
+    {
+      "start": 1163.71,
+      "end": 1164.27,
+      "text": "So,"
+    },
+    {
+      "start": 1164.28,
+      "end": 1164.68,
+      "text": "first"
+    },
+    {
+      "start": 1164.67,
+      "end": 1164.99,
+      "text": "on"
+    },
+    {
+      "start": 1164.99,
+      "end": 1165.23,
+      "text": "app"
+    },
+    {
+      "start": 1165.23,
+      "end": 1165.47,
+      "text": "view"
+    },
+    {
+      "start": 1165.47,
+      "end": 1165.95,
+      "text": "implementation"
+    },
+    {
+      "start": 1165.95,
+      "end": 1166.27,
+      "text": "and"
+    },
+    {
+      "start": 1166.28,
+      "end": 1166.76,
+      "text": "sync."
+    },
+    {
+      "start": 1166.76,
+      "end": 1167.24,
+      "text": "Relays"
+    },
+    {
+      "start": 1167.23,
+      "end": 1167.39,
+      "text": "are"
+    },
+    {
+      "start": 1167.39,
+      "end": 1167.63,
+      "text": "cheap"
+    },
+    {
+      "start": 1167.63,
+      "end": 1167.95,
+      "text": "now."
+    },
+    {
+      "start": 1167.95,
+      "end": 1168.11,
+      "text": "With"
+    },
+    {
+      "start": 1168.12,
+      "end": 1168.36,
+      "text": "sync"
+    },
+    {
+      "start": 1168.36,
+      "end": 1169.16,
+      "text": "1.1,"
+    },
+    {
+      "start": 1169.15,
+      "end": 1169.47,
+      "text": "FIG"
+    },
+    {
+      "start": 1169.47,
+      "end": 1169.63,
+      "text": "is"
+    },
+    {
+      "start": 1169.63,
+      "end": 1169.87,
+      "text": "running"
+    },
+    {
+      "start": 1169.88,
+      "end": 1170.04,
+      "text": "a"
+    },
+    {
+      "start": 1170.04,
+      "end": 1170.28,
+      "text": "relay"
+    },
+    {
+      "start": 1170.28,
+      "end": 1170.52,
+      "text": "for"
+    },
+    {
+      "start": 1170.52,
+      "end": 1170.76,
+      "text": "under"
+    },
+    {
+      "start": 1170.76,
+      "end": 1171.24,
+      "text": "$5"
+    },
+    {
+      "start": 1171.23,
+      "end": 1171.39,
+      "text": "a"
+    },
+    {
+      "start": 1171.39,
+      "end": 1171.79,
+      "text": "month."
+    },
+    {
+      "start": 1171.8,
+      "end": 1172.04,
+      "text": "That's"
+    },
+    {
+      "start": 1172.04,
+      "end": 1172.52,
+      "text": "awesome."
+    },
+    {
+      "start": 1172.52,
+      "end": 1172.76,
+      "text": "There's"
+    },
+    {
+      "start": 1172.76,
+      "end": 1172.92,
+      "text": "over"
+    },
+    {
+      "start": 1172.91,
+      "end": 1173.15,
+      "text": "10"
+    },
+    {
+      "start": 1173.15,
+      "end": 1173.47,
+      "text": "full"
+    },
+    {
+      "start": 1173.47,
+      "end": 1173.79,
+      "text": "network"
+    },
+    {
+      "start": 1173.8,
+      "end": 1174.28,
+      "text": "relays"
+    },
+    {
+      "start": 1174.28,
+      "end": 1174.52,
+      "text": "running"
+    },
+    {
+      "start": 1174.52,
+      "end": 1174.68,
+      "text": "in"
+    },
+    {
+      "start": 1174.67,
+      "end": 1174.75,
+      "text": "the"
+    },
+    {
+      "start": 1174.76,
+      "end": 1175.08,
+      "text": "network."
+    },
+    {
+      "start": 1175.55,
+      "end": 1175.87,
+      "text": "We"
+    },
+    {
+      "start": 1175.87,
+      "end": 1176.03,
+      "text": "seem"
+    },
+    {
+      "start": 1176.03,
+      "end": 1176.11,
+      "text": "to"
+    },
+    {
+      "start": 1176.11,
+      "end": 1176.35,
+      "text": "be"
+    },
+    {
+      "start": 1176.35,
+      "end": 1176.67,
+      "text": "getting"
+    },
+    {
+      "start": 1176.67,
+      "end": 1176.91,
+      "text": "pretty"
+    },
+    {
+      "start": 1176.91,
+      "end": 1177.07,
+      "text": "good"
+    },
+    {
+      "start": 1177.07,
+      "end": 1177.23,
+      "text": "at"
+    },
+    {
+      "start": 1177.23,
+      "end": 1177.39,
+      "text": "doing"
+    },
+    {
+      "start": 1177.39,
+      "end": 1177.55,
+      "text": "this"
+    },
+    {
+      "start": 1177.55,
+      "end": 1177.79,
+      "text": "one."
+    },
+    {
+      "start": 1177.79,
+      "end": 1177.95,
+      "text": "So"
+    },
+    {
+      "start": 1177.95,
+      "end": 1178.03,
+      "text": "you"
+    },
+    {
+      "start": 1178.03,
+      "end": 1178.11,
+      "text": "can"
+    },
+    {
+      "start": 1178.11,
+      "end": 1178.27,
+      "text": "get"
+    },
+    {
+      "start": 1178.27,
+      "end": 1178.43,
+      "text": "your"
+    },
+    {
+      "start": 1178.43,
+      "end": 1178.67,
+      "text": "data"
+    },
+    {
+      "start": 1178.67,
+      "end": 1178.83,
+      "text": "from"
+    },
+    {
+      "start": 1178.83,
+      "end": 1178.99,
+      "text": "a"
+    },
+    {
+      "start": 1178.99,
+      "end": 1179.07,
+      "text": "lot"
+    },
+    {
+      "start": 1179.07,
+      "end": 1179.23,
+      "text": "of"
+    },
+    {
+      "start": 1179.23,
+      "end": 1179.47,
+      "text": "different"
+    },
+    {
+      "start": 1179.47,
+      "end": 1180.11,
+      "text": "sources."
+    },
+    {
+      "start": 1180.51,
+      "end": 1180.99,
+      "text": "There's"
+    },
+    {
+      "start": 1180.99,
+      "end": 1181.15,
+      "text": "lots"
+    },
+    {
+      "start": 1181.15,
+      "end": 1181.23,
+      "text": "of"
+    },
+    {
+      "start": 1181.23,
+      "end": 1181.47,
+      "text": "new"
+    },
+    {
+      "start": 1181.47,
+      "end": 1181.71,
+      "text": "sync"
+    },
+    {
+      "start": 1181.71,
+      "end": 1181.95,
+      "text": "tools"
+    },
+    {
+      "start": 1181.95,
+      "end": 1182.27,
+      "text": "coming"
+    },
+    {
+      "start": 1182.27,
+      "end": 1182.75,
+      "text": "out."
+    },
+    {
+      "start": 1182.75,
+      "end": 1183.07,
+      "text": "We"
+    },
+    {
+      "start": 1183.07,
+      "end": 1183.39,
+      "text": "published"
+    },
+    {
+      "start": 1183.39,
+      "end": 1184.11,
+      "text": "TAP,"
+    },
+    {
+      "start": 1184.67,
+      "end": 1185.63,
+      "text": "hydrant,"
+    },
+    {
+      "start": 1186.03,
+      "end": 1186.27,
+      "text": "the"
+    },
+    {
+      "start": 1186.27,
+      "end": 1186.59,
+      "text": "entire"
+    },
+    {
+      "start": 1186.59,
+      "end": 1187.39,
+      "text": "FigProto"
+    },
+    {
+      "start": 1187.39,
+      "end": 1188.83,
+      "text": "Microcosm"
+    },
+    {
+      "start": 1188.58,
+      "end": 1189.38,
+      "text": "universe,"
+    },
+    {
+      "start": 1189.62,
+      "end": 1189.86,
+      "text": "is"
+    },
+    {
+      "start": 1189.86,
+      "end": 1190.1,
+      "text": "helping"
+    },
+    {
+      "start": 1190.1,
+      "end": 1190.34,
+      "text": "with"
+    },
+    {
+      "start": 1190.34,
+      "end": 1190.98,
+      "text": "sync."
+    },
+    {
+      "start": 1190.97,
+      "end": 1191.29,
+      "text": "And"
+    },
+    {
+      "start": 1191.3,
+      "end": 1191.54,
+      "text": "then,"
+    },
+    {
+      "start": 1191.54,
+      "end": 1192.02,
+      "text": "BlackSky"
+    },
+    {
+      "start": 1192.02,
+      "end": 1192.26,
+      "text": "is"
+    },
+    {
+      "start": 1192.26,
+      "end": 1192.5,
+      "text": "actually"
+    },
+    {
+      "start": 1192.49,
+      "end": 1192.89,
+      "text": "running"
+    },
+    {
+      "start": 1192.89,
+      "end": 1193.13,
+      "text": "a"
+    },
+    {
+      "start": 1193.13,
+      "end": 1193.37,
+      "text": "full"
+    },
+    {
+      "start": 1193.38,
+      "end": 1193.86,
+      "text": "network"
+    },
+    {
+      "start": 1193.86,
+      "end": 1194.1,
+      "text": "app"
+    },
+    {
+      "start": 1194.1,
+      "end": 1194.5,
+      "text": "view,"
+    },
+    {
+      "start": 1194.49,
+      "end": 1194.65,
+      "text": "which"
+    },
+    {
+      "start": 1194.65,
+      "end": 1194.81,
+      "text": "is"
+    },
+    {
+      "start": 1194.82,
+      "end": 1195.62,
+      "text": "incredible."
+    },
+    {
+      "start": 1201.93,
+      "end": 1202.49,
+      "text": "So"
+    },
+    {
+      "start": 1202.21,
+      "end": 1202.53,
+      "text": "in"
+    },
+    {
+      "start": 1202.53,
+      "end": 1202.69,
+      "text": "some"
+    },
+    {
+      "start": 1202.69,
+      "end": 1202.93,
+      "text": "sense,"
+    },
+    {
+      "start": 1202.93,
+      "end": 1203.09,
+      "text": "I"
+    },
+    {
+      "start": 1203.09,
+      "end": 1203.25,
+      "text": "kinda"
+    },
+    {
+      "start": 1203.25,
+      "end": 1203.41,
+      "text": "think"
+    },
+    {
+      "start": 1203.41,
+      "end": 1203.57,
+      "text": "this"
+    },
+    {
+      "start": 1203.57,
+      "end": 1203.89,
+      "text": "one's"
+    },
+    {
+      "start": 1203.89,
+      "end": 1204.05,
+      "text": "this"
+    },
+    {
+      "start": 1204.05,
+      "end": 1204.29,
+      "text": "one's"
+    },
+    {
+      "start": 1204.29,
+      "end": 1204.61,
+      "text": "solved."
+    },
+    {
+      "start": 1204.61,
+      "end": 1204.85,
+      "text": "Although,"
+    },
+    {
+      "start": 1204.85,
+      "end": 1204.93,
+      "text": "we"
+    },
+    {
+      "start": 1204.93,
+      "end": 1205.09,
+      "text": "can"
+    },
+    {
+      "start": 1205.09,
+      "end": 1205.25,
+      "text": "always"
+    },
+    {
+      "start": 1205.25,
+      "end": 1205.41,
+      "text": "do"
+    },
+    {
+      "start": 1205.41,
+      "end": 1205.57,
+      "text": "better"
+    },
+    {
+      "start": 1205.57,
+      "end": 1205.73,
+      "text": "on"
+    },
+    {
+      "start": 1205.73,
+      "end": 1205.89,
+      "text": "it."
+    },
+    {
+      "start": 1205.89,
+      "end": 1205.97,
+      "text": "But"
+    },
+    {
+      "start": 1205.97,
+      "end": 1206.21,
+      "text": "there's"
+    },
+    {
+      "start": 1206.21,
+      "end": 1206.37,
+      "text": "also"
+    },
+    {
+      "start": 1206.37,
+      "end": 1206.69,
+      "text": "novel"
+    },
+    {
+      "start": 1206.69,
+      "end": 1207.09,
+      "text": "approaches"
+    },
+    {
+      "start": 1207.09,
+      "end": 1207.33,
+      "text": "like"
+    },
+    {
+      "start": 1207.33,
+      "end": 1207.57,
+      "text": "Red"
+    },
+    {
+      "start": 1207.57,
+      "end": 1207.97,
+      "text": "Dwarf"
+    },
+    {
+      "start": 1207.97,
+      "end": 1208.21,
+      "text": "that"
+    },
+    {
+      "start": 1208.21,
+      "end": 1208.45,
+      "text": "provide"
+    },
+    {
+      "start": 1208.45,
+      "end": 1208.61,
+      "text": "a"
+    },
+    {
+      "start": 1208.61,
+      "end": 1208.85,
+      "text": "blue"
+    },
+    {
+      "start": 1208.85,
+      "end": 1209.17,
+      "text": "sky"
+    },
+    {
+      "start": 1209.17,
+      "end": 1209.49,
+      "text": "like"
+    },
+    {
+      "start": 1209.49,
+      "end": 1210.13,
+      "text": "experience"
+    },
+    {
+      "start": 1210.13,
+      "end": 1210.37,
+      "text": "with"
+    },
+    {
+      "start": 1210.37,
+      "end": 1210.53,
+      "text": "no"
+    },
+    {
+      "start": 1210.53,
+      "end": 1210.77,
+      "text": "app"
+    },
+    {
+      "start": 1210.77,
+      "end": 1211.33,
+      "text": "view."
+    },
+    {
+      "start": 1211.57,
+      "end": 1211.81,
+      "text": "And"
+    },
+    {
+      "start": 1211.81,
+      "end": 1212.13,
+      "text": "so,"
+    },
+    {
+      "start": 1212.13,
+      "end": 1212.37,
+      "text": "there's"
+    },
+    {
+      "start": 1212.37,
+      "end": 1212.61,
+      "text": "ways"
+    },
+    {
+      "start": 1212.61,
+      "end": 1212.77,
+      "text": "to"
+    },
+    {
+      "start": 1212.77,
+      "end": 1213.33,
+      "text": "rethink"
+    },
+    {
+      "start": 1213.33,
+      "end": 1213.65,
+      "text": "what"
+    },
+    {
+      "start": 1213.65,
+      "end": 1213.81,
+      "text": "this"
+    },
+    {
+      "start": 1213.81,
+      "end": 1214.05,
+      "text": "looks"
+    },
+    {
+      "start": 1214.05,
+      "end": 1214.21,
+      "text": "like"
+    },
+    {
+      "start": 1214.21,
+      "end": 1214.29,
+      "text": "in"
+    },
+    {
+      "start": 1214.29,
+      "end": 1214.45,
+      "text": "the"
+    },
+    {
+      "start": 1214.45,
+      "end": 1214.69,
+      "text": "network"
+    },
+    {
+      "start": 1214.69,
+      "end": 1214.93,
+      "text": "where"
+    },
+    {
+      "start": 1214.93,
+      "end": 1215.33,
+      "text": "maybe,"
+    },
+    {
+      "start": 1215.33,
+      "end": 1215.65,
+      "text": "I"
+    },
+    {
+      "start": 1215.51,
+      "end": 1215.67,
+      "text": "think"
+    },
+    {
+      "start": 1215.66,
+      "end": 1215.9,
+      "text": "it's"
+    },
+    {
+      "start": 1215.9,
+      "end": 1216.14,
+      "text": "amazing"
+    },
+    {
+      "start": 1216.14,
+      "end": 1216.38,
+      "text": "that"
+    },
+    {
+      "start": 1216.38,
+      "end": 1216.62,
+      "text": "Blast"
+    },
+    {
+      "start": 1216.63,
+      "end": 1216.71,
+      "text": "Sky"
+    },
+    {
+      "start": 1216.7,
+      "end": 1216.86,
+      "text": "is"
+    },
+    {
+      "start": 1216.87,
+      "end": 1217.03,
+      "text": "running"
+    },
+    {
+      "start": 1217.03,
+      "end": 1217.19,
+      "text": "a"
+    },
+    {
+      "start": 1217.18,
+      "end": 1217.34,
+      "text": "full"
+    },
+    {
+      "start": 1217.35,
+      "end": 1217.59,
+      "text": "network"
+    },
+    {
+      "start": 1217.59,
+      "end": 1217.83,
+      "text": "app"
+    },
+    {
+      "start": 1217.83,
+      "end": 1218.23,
+      "text": "view."
+    },
+    {
+      "start": 1218.22,
+      "end": 1218.38,
+      "text": "I"
+    },
+    {
+      "start": 1218.38,
+      "end": 1218.54,
+      "text": "think"
+    },
+    {
+      "start": 1218.54,
+      "end": 1218.7,
+      "text": "that"
+    },
+    {
+      "start": 1218.7,
+      "end": 1218.78,
+      "text": "you"
+    },
+    {
+      "start": 1218.78,
+      "end": 1218.94,
+      "text": "can"
+    },
+    {
+      "start": 1218.94,
+      "end": 1219.34,
+      "text": "probably"
+    },
+    {
+      "start": 1219.35,
+      "end": 1219.91,
+      "text": "provide"
+    },
+    {
+      "start": 1219.9,
+      "end": 1220.22,
+      "text": "Blue"
+    },
+    {
+      "start": 1220.22,
+      "end": 1220.54,
+      "text": "Sky"
+    },
+    {
+      "start": 1220.54,
+      "end": 1220.94,
+      "text": "like"
+    },
+    {
+      "start": 1220.94,
+      "end": 1221.9,
+      "text": "experiences"
+    },
+    {
+      "start": 1221.9,
+      "end": 1222.14,
+      "text": "for"
+    },
+    {
+      "start": 1222.14,
+      "end": 1222.7,
+      "text": "significantly"
+    },
+    {
+      "start": 1222.7,
+      "end": 1223.1,
+      "text": "cheaper"
+    },
+    {
+      "start": 1223.11,
+      "end": 1223.27,
+      "text": "if"
+    },
+    {
+      "start": 1223.27,
+      "end": 1223.43,
+      "text": "you"
+    },
+    {
+      "start": 1223.42,
+      "end": 1223.58,
+      "text": "make"
+    },
+    {
+      "start": 1223.59,
+      "end": 1223.91,
+      "text": "certain"
+    },
+    {
+      "start": 1223.9,
+      "end": 1224.14,
+      "text": "trade"
+    },
+    {
+      "start": 1224.14,
+      "end": 1224.38,
+      "text": "offs"
+    },
+    {
+      "start": 1224.38,
+      "end": 1224.62,
+      "text": "in"
+    },
+    {
+      "start": 1224.63,
+      "end": 1224.87,
+      "text": "how"
+    },
+    {
+      "start": 1224.87,
+      "end": 1225.03,
+      "text": "you"
+    },
+    {
+      "start": 1225.03,
+      "end": 1225.27,
+      "text": "in"
+    },
+    {
+      "start": 1225.27,
+      "end": 1225.51,
+      "text": "how"
+    },
+    {
+      "start": 1225.51,
+      "end": 1225.59,
+      "text": "you"
+    },
+    {
+      "start": 1225.59,
+      "end": 1226.07,
+      "text": "construct"
+    },
+    {
+      "start": 1226.07,
+      "end": 1226.23,
+      "text": "this."
+    },
+    {
+      "start": 1228.72,
+      "end": 1229.04,
+      "text": "The"
+    },
+    {
+      "start": 1229.04,
+      "end": 1229.2,
+      "text": "next"
+    },
+    {
+      "start": 1229.2,
+      "end": 1229.44,
+      "text": "one,"
+    },
+    {
+      "start": 1229.44,
+      "end": 1229.84,
+      "text": "Cuba"
+    },
+    {
+      "start": 1229.84,
+      "end": 1230.24,
+      "text": "joked"
+    },
+    {
+      "start": 1230.24,
+      "end": 1230.8,
+      "text": "that"
+    },
+    {
+      "start": 1231.52,
+      "end": 1231.76,
+      "text": "we"
+    },
+    {
+      "start": 1231.76,
+      "end": 1232,
+      "text": "should"
+    },
+    {
+      "start": 1232,
+      "end": 1232.16,
+      "text": "take"
+    },
+    {
+      "start": 1232.16,
+      "end": 1232.32,
+      "text": "a"
+    },
+    {
+      "start": 1232.32,
+      "end": 1232.48,
+      "text": "shot"
+    },
+    {
+      "start": 1232.48,
+      "end": 1232.8,
+      "text": "every"
+    },
+    {
+      "start": 1232.8,
+      "end": 1232.96,
+      "text": "time"
+    },
+    {
+      "start": 1232.96,
+      "end": 1233.52,
+      "text": "this"
+    },
+    {
+      "start": 1233.68,
+      "end": 1234.08,
+      "text": "graph"
+    },
+    {
+      "start": 1234.08,
+      "end": 1234.32,
+      "text": "is"
+    },
+    {
+      "start": 1234.32,
+      "end": 1234.56,
+      "text": "showed"
+    },
+    {
+      "start": 1234.56,
+      "end": 1234.72,
+      "text": "at"
+    },
+    {
+      "start": 1234.72,
+      "end": 1234.8,
+      "text": "the"
+    },
+    {
+      "start": 1234.8,
+      "end": 1235.2,
+      "text": "conference,"
+    },
+    {
+      "start": 1235.2,
+      "end": 1235.28,
+      "text": "and"
+    },
+    {
+      "start": 1235.28,
+      "end": 1235.36,
+      "text": "I"
+    },
+    {
+      "start": 1235.36,
+      "end": 1235.52,
+      "text": "told"
+    },
+    {
+      "start": 1235.52,
+      "end": 1235.6,
+      "text": "him"
+    },
+    {
+      "start": 1235.6,
+      "end": 1235.76,
+      "text": "I"
+    },
+    {
+      "start": 1235.76,
+      "end": 1235.92,
+      "text": "got"
+    },
+    {
+      "start": 1235.92,
+      "end": 1236.16,
+      "text": "one"
+    },
+    {
+      "start": 1236.16,
+      "end": 1236.48,
+      "text": "one"
+    },
+    {
+      "start": 1236.48,
+      "end": 1236.64,
+      "text": "more"
+    },
+    {
+      "start": 1236.64,
+      "end": 1236.88,
+      "text": "for"
+    },
+    {
+      "start": 1236.88,
+      "end": 1237.36,
+      "text": "him."
+    },
+    {
+      "start": 1238.16,
+      "end": 1238.48,
+      "text": "The"
+    },
+    {
+      "start": 1238.48,
+      "end": 1238.64,
+      "text": "next"
+    },
+    {
+      "start": 1238.64,
+      "end": 1238.8,
+      "text": "one"
+    },
+    {
+      "start": 1238.8,
+      "end": 1239.04,
+      "text": "is"
+    },
+    {
+      "start": 1239.04,
+      "end": 1239.28,
+      "text": "more"
+    },
+    {
+      "start": 1239.28,
+      "end": 1239.68,
+      "text": "users"
+    },
+    {
+      "start": 1239.68,
+      "end": 1239.92,
+      "text": "on"
+    },
+    {
+      "start": 1239.92,
+      "end": 1240.16,
+      "text": "non"
+    },
+    {
+      "start": 1240.16,
+      "end": 1240.4,
+      "text": "blue"
+    },
+    {
+      "start": 1240.4,
+      "end": 1240.64,
+      "text": "sky"
+    },
+    {
+      "start": 1240.64,
+      "end": 1241.68,
+      "text": "PDSs."
+    },
+    {
+      "start": 1241.84,
+      "end": 1242.16,
+      "text": "This"
+    },
+    {
+      "start": 1242.16,
+      "end": 1242.32,
+      "text": "is"
+    },
+    {
+      "start": 1242.32,
+      "end": 1242.48,
+      "text": "a"
+    },
+    {
+      "start": 1242.48,
+      "end": 1243.28,
+      "text": "graph"
+    },
+    {
+      "start": 1242.73,
+      "end": 1242.97,
+      "text": "of"
+    },
+    {
+      "start": 1242.97,
+      "end": 1243.37,
+      "text": "weekly"
+    },
+    {
+      "start": 1243.38,
+      "end": 1243.7,
+      "text": "users"
+    },
+    {
+      "start": 1243.69,
+      "end": 1244.17,
+      "text": "posting"
+    },
+    {
+      "start": 1244.17,
+      "end": 1244.33,
+      "text": "from"
+    },
+    {
+      "start": 1244.34,
+      "end": 1244.5,
+      "text": "non"
+    },
+    {
+      "start": 1244.49,
+      "end": 1245.05,
+      "text": "Blue"
+    },
+    {
+      "start": 1245.05,
+      "end": 1245.21,
+      "text": "Sky"
+    },
+    {
+      "start": 1245.21,
+      "end": 1245.85,
+      "text": "PDSs,"
+    },
+    {
+      "start": 1245.86,
+      "end": 1245.94,
+      "text": "and"
+    },
+    {
+      "start": 1245.93,
+      "end": 1246.01,
+      "text": "you"
+    },
+    {
+      "start": 1246.02,
+      "end": 1246.18,
+      "text": "can"
+    },
+    {
+      "start": 1246.17,
+      "end": 1246.25,
+      "text": "see"
+    },
+    {
+      "start": 1246.26,
+      "end": 1246.42,
+      "text": "that"
+    },
+    {
+      "start": 1246.41,
+      "end": 1246.57,
+      "text": "the"
+    },
+    {
+      "start": 1246.58,
+      "end": 1246.82,
+      "text": "trend"
+    },
+    {
+      "start": 1246.82,
+      "end": 1247.06,
+      "text": "line"
+    },
+    {
+      "start": 1247.05,
+      "end": 1247.21,
+      "text": "is"
+    },
+    {
+      "start": 1247.21,
+      "end": 1247.45,
+      "text": "pretty"
+    },
+    {
+      "start": 1247.45,
+      "end": 1247.93,
+      "text": "good."
+    },
+    {
+      "start": 1248.02,
+      "end": 1248.26,
+      "text": "So"
+    },
+    {
+      "start": 1248.26,
+      "end": 1248.58,
+      "text": "in"
+    },
+    {
+      "start": 1248.58,
+      "end": 1248.74,
+      "text": "some"
+    },
+    {
+      "start": 1248.73,
+      "end": 1249.13,
+      "text": "sense,"
+    },
+    {
+      "start": 1249.13,
+      "end": 1249.21,
+      "text": "we"
+    },
+    {
+      "start": 1249.21,
+      "end": 1249.37,
+      "text": "just"
+    },
+    {
+      "start": 1249.38,
+      "end": 1249.54,
+      "text": "gotta"
+    },
+    {
+      "start": 1249.54,
+      "end": 1249.78,
+      "text": "keep"
+    },
+    {
+      "start": 1249.78,
+      "end": 1250.1,
+      "text": "cooking"
+    },
+    {
+      "start": 1250.1,
+      "end": 1250.26,
+      "text": "on"
+    },
+    {
+      "start": 1250.26,
+      "end": 1250.34,
+      "text": "this"
+    },
+    {
+      "start": 1250.34,
+      "end": 1250.58,
+      "text": "and"
+    },
+    {
+      "start": 1250.58,
+      "end": 1250.74,
+      "text": "doing"
+    },
+    {
+      "start": 1250.73,
+      "end": 1250.89,
+      "text": "what"
+    },
+    {
+      "start": 1250.89,
+      "end": 1251.05,
+      "text": "we're"
+    },
+    {
+      "start": 1251.05,
+      "end": 1251.53,
+      "text": "doing."
+    },
+    {
+      "start": 1252.02,
+      "end": 1252.18,
+      "text": "What"
+    },
+    {
+      "start": 1252.17,
+      "end": 1252.41,
+      "text": "Blue"
+    },
+    {
+      "start": 1252.41,
+      "end": 1252.65,
+      "text": "Sky"
+    },
+    {
+      "start": 1252.73,
+      "end": 1252.89,
+      "text": "what"
+    },
+    {
+      "start": 1252.89,
+      "end": 1253.05,
+      "text": "we"
+    },
+    {
+      "start": 1253.05,
+      "end": 1253.13,
+      "text": "can"
+    },
+    {
+      "start": 1253.13,
+      "end": 1253.29,
+      "text": "do"
+    },
+    {
+      "start": 1253.3,
+      "end": 1253.46,
+      "text": "and"
+    },
+    {
+      "start": 1253.45,
+      "end": 1253.61,
+      "text": "what"
+    },
+    {
+      "start": 1253.62,
+      "end": 1253.86,
+      "text": "we're"
+    },
+    {
+      "start": 1253.86,
+      "end": 1254.18,
+      "text": "planning"
+    },
+    {
+      "start": 1254.17,
+      "end": 1254.25,
+      "text": "to"
+    },
+    {
+      "start": 1254.26,
+      "end": 1254.42,
+      "text": "do"
+    },
+    {
+      "start": 1254.41,
+      "end": 1254.57,
+      "text": "to"
+    },
+    {
+      "start": 1254.58,
+      "end": 1254.74,
+      "text": "help"
+    },
+    {
+      "start": 1254.73,
+      "end": 1254.89,
+      "text": "with"
+    },
+    {
+      "start": 1254.89,
+      "end": 1255.05,
+      "text": "this"
+    },
+    {
+      "start": 1255.05,
+      "end": 1255.29,
+      "text": "is"
+    },
+    {
+      "start": 1255.3,
+      "end": 1255.54,
+      "text": "putting"
+    },
+    {
+      "start": 1255.54,
+      "end": 1255.7,
+      "text": "an"
+    },
+    {
+      "start": 1255.69,
+      "end": 1256.01,
+      "text": "account"
+    },
+    {
+      "start": 1256.02,
+      "end": 1256.42,
+      "text": "migration"
+    },
+    {
+      "start": 1256.41,
+      "end": 1256.73,
+      "text": "UI"
+    },
+    {
+      "start": 1256.73,
+      "end": 1256.97,
+      "text": "in"
+    },
+    {
+      "start": 1256.97,
+      "end": 1257.05,
+      "text": "the"
+    },
+    {
+      "start": 1257.05,
+      "end": 1257.45,
+      "text": "PDS."
+    },
+    {
+      "start": 1258.17,
+      "end": 1258.41,
+      "text": "We"
+    },
+    {
+      "start": 1258.41,
+      "end": 1258.65,
+      "text": "think"
+    },
+    {
+      "start": 1258.65,
+      "end": 1258.89,
+      "text": "that"
+    },
+    {
+      "start": 1258.89,
+      "end": 1259.61,
+      "text": "users,"
+    },
+    {
+      "start": 1259.61,
+      "end": 1259.77,
+      "text": "especially"
+    },
+    {
+      "start": 1259.77,
+      "end": 1260.01,
+      "text": "non"
+    },
+    {
+      "start": 1260.01,
+      "end": 1260.33,
+      "text": "technical"
+    },
+    {
+      "start": 1260.33,
+      "end": 1260.97,
+      "text": "users,"
+    },
+    {
+      "start": 1260.97,
+      "end": 1261.37,
+      "text": "probably"
+    },
+    {
+      "start": 1261.37,
+      "end": 1261.61,
+      "text": "just"
+    },
+    {
+      "start": 1261.61,
+      "end": 1261.77,
+      "text": "have"
+    },
+    {
+      "start": 1261.77,
+      "end": 1261.93,
+      "text": "a"
+    },
+    {
+      "start": 1261.93,
+      "end": 1262.09,
+      "text": "better"
+    },
+    {
+      "start": 1262.09,
+      "end": 1262.41,
+      "text": "trust"
+    },
+    {
+      "start": 1262.41,
+      "end": 1262.89,
+      "text": "relationship"
+    },
+    {
+      "start": 1262.89,
+      "end": 1263.05,
+      "text": "with"
+    },
+    {
+      "start": 1263.05,
+      "end": 1263.21,
+      "text": "the"
+    },
+    {
+      "start": 1263.21,
+      "end": 1263.37,
+      "text": "Blue"
+    },
+    {
+      "start": 1263.37,
+      "end": 1263.85,
+      "text": "Sky"
+    },
+    {
+      "start": 1263.85,
+      "end": 1264.81,
+      "text": "PDS"
+    },
+    {
+      "start": 1265.05,
+      "end": 1265.61,
+      "text": "or"
+    },
+    {
+      "start": 1265.77,
+      "end": 1266.01,
+      "text": "yeah."
+    },
+    {
+      "start": 1266.01,
+      "end": 1266.17,
+      "text": "With"
+    },
+    {
+      "start": 1266.17,
+      "end": 1266.25,
+      "text": "the"
+    },
+    {
+      "start": 1266.25,
+      "end": 1266.41,
+      "text": "Blue"
+    },
+    {
+      "start": 1266.41,
+      "end": 1266.65,
+      "text": "Sky"
+    },
+    {
+      "start": 1266.65,
+      "end": 1267.05,
+      "text": "PDS"
+    },
+    {
+      "start": 1267.05,
+      "end": 1267.21,
+      "text": "and"
+    },
+    {
+      "start": 1267.21,
+      "end": 1267.37,
+      "text": "would"
+    },
+    {
+      "start": 1267.37,
+      "end": 1267.61,
+      "text": "trust"
+    },
+    {
+      "start": 1267.61,
+      "end": 1267.85,
+      "text": "an"
+    },
+    {
+      "start": 1267.85,
+      "end": 1268.09,
+      "text": "account"
+    },
+    {
+      "start": 1268.09,
+      "end": 1268.49,
+      "text": "migration"
+    },
+    {
+      "start": 1268.49,
+      "end": 1268.81,
+      "text": "UI"
+    },
+    {
+      "start": 1268.81,
+      "end": 1269.29,
+      "text": "there"
+    },
+    {
+      "start": 1269.29,
+      "end": 1269.53,
+      "text": "a"
+    },
+    {
+      "start": 1269.53,
+      "end": 1269.69,
+      "text": "little"
+    },
+    {
+      "start": 1269.69,
+      "end": 1269.85,
+      "text": "bit"
+    },
+    {
+      "start": 1269.85,
+      "end": 1270.09,
+      "text": "more"
+    },
+    {
+      "start": 1270.09,
+      "end": 1270.33,
+      "text": "to"
+    },
+    {
+      "start": 1270.33,
+      "end": 1270.49,
+      "text": "get"
+    },
+    {
+      "start": 1270.49,
+      "end": 1270.73,
+      "text": "over"
+    },
+    {
+      "start": 1270.73,
+      "end": 1270.81,
+      "text": "to"
+    },
+    {
+      "start": 1270.81,
+      "end": 1271.13,
+      "text": "non"
+    },
+    {
+      "start": 1271.13,
+      "end": 1271.77,
+      "text": "Blue"
+    },
+    {
+      "start": 1271.77,
+      "end": 1272.01,
+      "text": "Sky"
+    },
+    {
+      "start": 1272.01,
+      "end": 1272.41,
+      "text": "PDS"
+    },
+    {
+      "start": 1272.41,
+      "end": 1272.81,
+      "text": "hosting."
+    },
+    {
+      "start": 1273.58,
+      "end": 1273.9,
+      "text": "We"
+    },
+    {
+      "start": 1273.89,
+      "end": 1274.05,
+      "text": "wanna"
+    },
+    {
+      "start": 1274.05,
+      "end": 1274.37,
+      "text": "improve"
+    },
+    {
+      "start": 1274.38,
+      "end": 1274.54,
+      "text": "the"
+    },
+    {
+      "start": 1274.53,
+      "end": 1275.01,
+      "text": "PDS"
+    },
+    {
+      "start": 1275.02,
+      "end": 1275.66,
+      "text": "distribution"
+    },
+    {
+      "start": 1275.65,
+      "end": 1276.05,
+      "text": "especially"
+    },
+    {
+      "start": 1276.05,
+      "end": 1276.29,
+      "text": "for"
+    },
+    {
+      "start": 1276.29,
+      "end": 1276.53,
+      "text": "mid"
+    },
+    {
+      "start": 1276.53,
+      "end": 1276.77,
+      "text": "sized"
+    },
+    {
+      "start": 1276.78,
+      "end": 1277.5,
+      "text": "deployments,"
+    },
+    {
+      "start": 1277.49,
+      "end": 1277.57,
+      "text": "things"
+    },
+    {
+      "start": 1277.58,
+      "end": 1277.82,
+      "text": "in"
+    },
+    {
+      "start": 1277.82,
+      "end": 1277.9,
+      "text": "the"
+    },
+    {
+      "start": 1277.89,
+      "end": 1278.45,
+      "text": "1,000"
+    },
+    {
+      "start": 1278.45,
+      "end": 1278.69,
+      "text": "to"
+    },
+    {
+      "start": 1278.69,
+      "end": 1278.85,
+      "text": "a"
+    },
+    {
+      "start": 1278.86,
+      "end": 1279.34,
+      "text": "100,000"
+    },
+    {
+      "start": 1279.34,
+      "end": 1279.82,
+      "text": "user"
+    },
+    {
+      "start": 1279.82,
+      "end": 1280.3,
+      "text": "range."
+    },
+    {
+      "start": 1280.29,
+      "end": 1280.45,
+      "text": "Right"
+    },
+    {
+      "start": 1280.45,
+      "end": 1280.61,
+      "text": "now,"
+    },
+    {
+      "start": 1280.62,
+      "end": 1280.7,
+      "text": "it"
+    },
+    {
+      "start": 1280.69,
+      "end": 1281.01,
+      "text": "works"
+    },
+    {
+      "start": 1281.02,
+      "end": 1281.34,
+      "text": "pretty"
+    },
+    {
+      "start": 1281.34,
+      "end": 1281.5,
+      "text": "well"
+    },
+    {
+      "start": 1281.49,
+      "end": 1281.65,
+      "text": "for"
+    },
+    {
+      "start": 1281.65,
+      "end": 1281.97,
+      "text": "self"
+    },
+    {
+      "start": 1281.97,
+      "end": 1282.37,
+      "text": "hosters"
+    },
+    {
+      "start": 1282.38,
+      "end": 1282.54,
+      "text": "and"
+    },
+    {
+      "start": 1282.53,
+      "end": 1282.77,
+      "text": "small"
+    },
+    {
+      "start": 1282.78,
+      "end": 1283.02,
+      "text": "groups"
+    },
+    {
+      "start": 1283.02,
+      "end": 1283.18,
+      "text": "of"
+    },
+    {
+      "start": 1283.17,
+      "end": 1283.65,
+      "text": "people."
+    },
+    {
+      "start": 1283.65,
+      "end": 1283.89,
+      "text": "It's"
+    },
+    {
+      "start": 1283.89,
+      "end": 1283.97,
+      "text": "a"
+    },
+    {
+      "start": 1283.97,
+      "end": 1284.05,
+      "text": "little"
+    },
+    {
+      "start": 1284.05,
+      "end": 1284.21,
+      "text": "bit"
+    },
+    {
+      "start": 1284.21,
+      "end": 1284.29,
+      "text": "of"
+    },
+    {
+      "start": 1284.29,
+      "end": 1284.45,
+      "text": "a"
+    },
+    {
+      "start": 1284.45,
+      "end": 1284.93,
+      "text": "pain"
+    },
+    {
+      "start": 1284.93,
+      "end": 1285.25,
+      "text": "for"
+    },
+    {
+      "start": 1285.26,
+      "end": 1285.58,
+      "text": "mid"
+    },
+    {
+      "start": 1285.58,
+      "end": 1285.82,
+      "text": "sized"
+    },
+    {
+      "start": 1285.82,
+      "end": 1286.3,
+      "text": "deployments."
+    },
+    {
+      "start": 1286.62,
+      "end": 1286.86,
+      "text": "We"
+    },
+    {
+      "start": 1286.86,
+      "end": 1287.1,
+      "text": "also"
+    },
+    {
+      "start": 1287.1,
+      "end": 1287.26,
+      "text": "wanna"
+    },
+    {
+      "start": 1287.26,
+      "end": 1287.42,
+      "text": "make"
+    },
+    {
+      "start": 1287.42,
+      "end": 1287.58,
+      "text": "the"
+    },
+    {
+      "start": 1287.58,
+      "end": 1287.9,
+      "text": "relay"
+    },
+    {
+      "start": 1287.9,
+      "end": 1288.7,
+      "text": "more"
+    },
+    {
+      "start": 1289.02,
+      "end": 1289.42,
+      "text": "self"
+    },
+    {
+      "start": 1289.42,
+      "end": 1290.14,
+      "text": "serve"
+    },
+    {
+      "start": 1290.14,
+      "end": 1290.54,
+      "text": "both"
+    },
+    {
+      "start": 1290.54,
+      "end": 1291.1,
+      "text": "for"
+    },
+    {
+      "start": 1291.1,
+      "end": 1291.5,
+      "text": "third"
+    },
+    {
+      "start": 1291.5,
+      "end": 1291.9,
+      "text": "party"
+    },
+    {
+      "start": 1291.9,
+      "end": 1292.62,
+      "text": "relays,"
+    },
+    {
+      "start": 1292.62,
+      "end": 1292.7,
+      "text": "so"
+    },
+    {
+      "start": 1292.7,
+      "end": 1292.86,
+      "text": "that"
+    },
+    {
+      "start": 1292.86,
+      "end": 1293.1,
+      "text": "it's"
+    },
+    {
+      "start": 1293.1,
+      "end": 1293.42,
+      "text": "easier"
+    },
+    {
+      "start": 1293.42,
+      "end": 1293.58,
+      "text": "for"
+    },
+    {
+      "start": 1293.58,
+      "end": 1293.82,
+      "text": "them"
+    },
+    {
+      "start": 1293.82,
+      "end": 1293.98,
+      "text": "to"
+    },
+    {
+      "start": 1293.98,
+      "end": 1294.22,
+      "text": "get"
+    },
+    {
+      "start": 1294.22,
+      "end": 1294.7,
+      "text": "proactive"
+    },
+    {
+      "start": 1294.7,
+      "end": 1295.02,
+      "text": "right"
+    },
+    {
+      "start": 1295.02,
+      "end": 1295.58,
+      "text": "notifications"
+    },
+    {
+      "start": 1295.58,
+      "end": 1295.98,
+      "text": "whenever"
+    },
+    {
+      "start": 1295.98,
+      "end": 1296.46,
+      "text": "PDS"
+    },
+    {
+      "start": 1296.46,
+      "end": 1296.62,
+      "text": "is"
+    },
+    {
+      "start": 1296.62,
+      "end": 1297.18,
+      "text": "right."
+    },
+    {
+      "start": 1297.18,
+      "end": 1297.26,
+      "text": "But"
+    },
+    {
+      "start": 1297.26,
+      "end": 1297.5,
+      "text": "also"
+    },
+    {
+      "start": 1297.5,
+      "end": 1297.74,
+      "text": "for"
+    },
+    {
+      "start": 1297.74,
+      "end": 1297.98,
+      "text": "our"
+    },
+    {
+      "start": 1297.98,
+      "end": 1298.3,
+      "text": "relay"
+    },
+    {
+      "start": 1298.3,
+      "end": 1298.62,
+      "text": "doing"
+    },
+    {
+      "start": 1298.62,
+      "end": 1299.1,
+      "text": "dynamic"
+    },
+    {
+      "start": 1299.1,
+      "end": 1299.34,
+      "text": "rate"
+    },
+    {
+      "start": 1299.34,
+      "end": 1299.74,
+      "text": "limits,"
+    },
+    {
+      "start": 1299.74,
+      "end": 1299.82,
+      "text": "so"
+    },
+    {
+      "start": 1299.82,
+      "end": 1299.9,
+      "text": "that"
+    },
+    {
+      "start": 1299.9,
+      "end": 1300.06,
+      "text": "you"
+    },
+    {
+      "start": 1300.06,
+      "end": 1300.22,
+      "text": "guys"
+    },
+    {
+      "start": 1300.22,
+      "end": 1300.46,
+      "text": "don't"
+    },
+    {
+      "start": 1300.46,
+      "end": 1300.54,
+      "text": "have"
+    },
+    {
+      "start": 1300.54,
+      "end": 1300.78,
+      "text": "to"
+    },
+    {
+      "start": 1300.95,
+      "end": 1301.43,
+      "text": "DM"
+    },
+    {
+      "start": 1301.43,
+      "end": 1301.67,
+      "text": "us"
+    },
+    {
+      "start": 1301.67,
+      "end": 1302.15,
+      "text": "whenever"
+    },
+    {
+      "start": 1302.15,
+      "end": 1302.47,
+      "text": "you"
+    },
+    {
+      "start": 1302.47,
+      "end": 1302.87,
+      "text": "run"
+    },
+    {
+      "start": 1302.88,
+      "end": 1303.28,
+      "text": "into"
+    },
+    {
+      "start": 1303.28,
+      "end": 1303.6,
+      "text": "that"
+    },
+    {
+      "start": 1303.6,
+      "end": 1303.76,
+      "text": "and"
+    },
+    {
+      "start": 1303.76,
+      "end": 1303.92,
+      "text": "you"
+    },
+    {
+      "start": 1303.91,
+      "end": 1304.07,
+      "text": "get"
+    },
+    {
+      "start": 1304.08,
+      "end": 1304.32,
+      "text": "cut"
+    },
+    {
+      "start": 1304.32,
+      "end": 1304.48,
+      "text": "off"
+    },
+    {
+      "start": 1304.47,
+      "end": 1304.63,
+      "text": "from"
+    },
+    {
+      "start": 1304.63,
+      "end": 1304.71,
+      "text": "the"
+    },
+    {
+      "start": 1304.71,
+      "end": 1305.35,
+      "text": "relay."
+    },
+    {
+      "start": 1306.8,
+      "end": 1307.04,
+      "text": "What"
+    },
+    {
+      "start": 1307.04,
+      "end": 1307.36,
+      "text": "what"
+    },
+    {
+      "start": 1307.36,
+      "end": 1307.52,
+      "text": "you"
+    },
+    {
+      "start": 1307.52,
+      "end": 1307.76,
+      "text": "all"
+    },
+    {
+      "start": 1307.76,
+      "end": 1307.92,
+      "text": "can"
+    },
+    {
+      "start": 1307.91,
+      "end": 1308.07,
+      "text": "do"
+    },
+    {
+      "start": 1308.08,
+      "end": 1308.24,
+      "text": "for"
+    },
+    {
+      "start": 1308.23,
+      "end": 1308.39,
+      "text": "this"
+    },
+    {
+      "start": 1308.39,
+      "end": 1308.79,
+      "text": "to"
+    },
+    {
+      "start": 1308.8,
+      "end": 1309.2,
+      "text": "improve"
+    },
+    {
+      "start": 1309.19,
+      "end": 1309.43,
+      "text": "this"
+    },
+    {
+      "start": 1309.43,
+      "end": 1309.75,
+      "text": "is"
+    },
+    {
+      "start": 1309.76,
+      "end": 1310.16,
+      "text": "keep"
+    },
+    {
+      "start": 1310.15,
+      "end": 1310.87,
+      "text": "cooking"
+    },
+    {
+      "start": 1311.04,
+      "end": 1311.52,
+      "text": "and"
+    },
+    {
+      "start": 1311.52,
+      "end": 1311.84,
+      "text": "also"
+    },
+    {
+      "start": 1311.84,
+      "end": 1312.32,
+      "text": "backup"
+    },
+    {
+      "start": 1312.32,
+      "end": 1312.56,
+      "text": "and"
+    },
+    {
+      "start": 1312.56,
+      "end": 1313.04,
+      "text": "recovery"
+    },
+    {
+      "start": 1313.04,
+      "end": 1313.52,
+      "text": "systems."
+    },
+    {
+      "start": 1313.52,
+      "end": 1313.68,
+      "text": "We"
+    },
+    {
+      "start": 1313.67,
+      "end": 1313.91,
+      "text": "talked"
+    },
+    {
+      "start": 1313.91,
+      "end": 1314.55,
+      "text": "about"
+    },
+    {
+      "start": 1314.12,
+      "end": 1314.52,
+      "text": "backup"
+    },
+    {
+      "start": 1314.52,
+      "end": 1314.76,
+      "text": "and"
+    },
+    {
+      "start": 1314.76,
+      "end": 1315.16,
+      "text": "recovery"
+    },
+    {
+      "start": 1315.16,
+      "end": 1315.56,
+      "text": "systems"
+    },
+    {
+      "start": 1315.56,
+      "end": 1315.8,
+      "text": "in"
+    },
+    {
+      "start": 1315.8,
+      "end": 1315.96,
+      "text": "the"
+    },
+    {
+      "start": 1315.96,
+      "end": 1316.44,
+      "text": "context"
+    },
+    {
+      "start": 1316.44,
+      "end": 1317,
+      "text": "of"
+    },
+    {
+      "start": 1317.08,
+      "end": 1317.4,
+      "text": "sort"
+    },
+    {
+      "start": 1317.4,
+      "end": 1317.64,
+      "text": "of"
+    },
+    {
+      "start": 1317.64,
+      "end": 1317.96,
+      "text": "Blue"
+    },
+    {
+      "start": 1317.96,
+      "end": 1318.44,
+      "text": "Sky"
+    },
+    {
+      "start": 1318.44,
+      "end": 1319.32,
+      "text": "threatening"
+    },
+    {
+      "start": 1319.32,
+      "end": 1319.8,
+      "text": "people's"
+    },
+    {
+      "start": 1319.8,
+      "end": 1320.44,
+      "text": "repositories"
+    },
+    {
+      "start": 1320.44,
+      "end": 1320.68,
+      "text": "and"
+    },
+    {
+      "start": 1320.68,
+      "end": 1321.32,
+      "text": "keys,"
+    },
+    {
+      "start": 1321.32,
+      "end": 1321.4,
+      "text": "but"
+    },
+    {
+      "start": 1321.4,
+      "end": 1321.64,
+      "text": "it's"
+    },
+    {
+      "start": 1321.64,
+      "end": 1321.88,
+      "text": "also"
+    },
+    {
+      "start": 1321.88,
+      "end": 1322.28,
+      "text": "important"
+    },
+    {
+      "start": 1322.28,
+      "end": 1322.52,
+      "text": "for"
+    },
+    {
+      "start": 1322.52,
+      "end": 1323.16,
+      "text": "migrating"
+    },
+    {
+      "start": 1323.16,
+      "end": 1323.4,
+      "text": "off"
+    },
+    {
+      "start": 1323.4,
+      "end": 1323.56,
+      "text": "to"
+    },
+    {
+      "start": 1323.56,
+      "end": 1324.28,
+      "text": "non"
+    },
+    {
+      "start": 1324.28,
+      "end": 1324.6,
+      "text": "Blue"
+    },
+    {
+      "start": 1324.6,
+      "end": 1324.84,
+      "text": "Sky"
+    },
+    {
+      "start": 1324.84,
+      "end": 1325.72,
+      "text": "PDSs"
+    },
+    {
+      "start": 1325.72,
+      "end": 1326.52,
+      "text": "because"
+    },
+    {
+      "start": 1326.88,
+      "end": 1327.12,
+      "text": "you"
+    },
+    {
+      "start": 1327.13,
+      "end": 1327.37,
+      "text": "you"
+    },
+    {
+      "start": 1327.37,
+      "end": 1327.61,
+      "text": "don't"
+    },
+    {
+      "start": 1327.61,
+      "end": 1328.17,
+      "text": "necessarily"
+    },
+    {
+      "start": 1328.4,
+      "end": 1328.48,
+      "text": "you"
+    },
+    {
+      "start": 1328.48,
+      "end": 1328.64,
+      "text": "you"
+    },
+    {
+      "start": 1328.64,
+      "end": 1328.88,
+      "text": "know,"
+    },
+    {
+      "start": 1328.88,
+      "end": 1329.04,
+      "text": "you're"
+    },
+    {
+      "start": 1329.05,
+      "end": 1329.21,
+      "text": "taking"
+    },
+    {
+      "start": 1329.21,
+      "end": 1329.37,
+      "text": "on"
+    },
+    {
+      "start": 1329.37,
+      "end": 1329.53,
+      "text": "an"
+    },
+    {
+      "start": 1329.53,
+      "end": 1330.01,
+      "text": "operational"
+    },
+    {
+      "start": 1330.01,
+      "end": 1330.33,
+      "text": "risk"
+    },
+    {
+      "start": 1330.33,
+      "end": 1330.65,
+      "text": "whenever"
+    },
+    {
+      "start": 1330.64,
+      "end": 1330.8,
+      "text": "you"
+    },
+    {
+      "start": 1330.81,
+      "end": 1330.97,
+      "text": "do"
+    },
+    {
+      "start": 1330.96,
+      "end": 1331.2,
+      "text": "that."
+    },
+    {
+      "start": 1331.21,
+      "end": 1331.29,
+      "text": "You"
+    },
+    {
+      "start": 1331.29,
+      "end": 1331.45,
+      "text": "kind"
+    },
+    {
+      "start": 1331.45,
+      "end": 1331.53,
+      "text": "of"
+    },
+    {
+      "start": 1331.53,
+      "end": 1332.09,
+      "text": "know"
+    },
+    {
+      "start": 1332.4,
+      "end": 1332.8,
+      "text": "Blue"
+    },
+    {
+      "start": 1332.81,
+      "end": 1333.05,
+      "text": "Sky"
+    },
+    {
+      "start": 1333.05,
+      "end": 1333.29,
+      "text": "has"
+    },
+    {
+      "start": 1333.29,
+      "end": 1333.53,
+      "text": "money"
+    },
+    {
+      "start": 1333.53,
+      "end": 1333.77,
+      "text": "and"
+    },
+    {
+      "start": 1333.77,
+      "end": 1333.93,
+      "text": "we"
+    },
+    {
+      "start": 1334.01,
+      "end": 1334.17,
+      "text": "and"
+    },
+    {
+      "start": 1334.16,
+      "end": 1334.32,
+      "text": "you"
+    },
+    {
+      "start": 1334.33,
+      "end": 1334.49,
+      "text": "know"
+    },
+    {
+      "start": 1334.48,
+      "end": 1334.64,
+      "text": "how"
+    },
+    {
+      "start": 1334.64,
+      "end": 1334.72,
+      "text": "we"
+    },
+    {
+      "start": 1334.72,
+      "end": 1335.04,
+      "text": "operate"
+    },
+    {
+      "start": 1335.05,
+      "end": 1335.29,
+      "text": "stuff"
+    },
+    {
+      "start": 1335.29,
+      "end": 1335.53,
+      "text": "and"
+    },
+    {
+      "start": 1335.53,
+      "end": 1335.61,
+      "text": "you"
+    },
+    {
+      "start": 1335.61,
+      "end": 1335.69,
+      "text": "know"
+    },
+    {
+      "start": 1335.68,
+      "end": 1335.84,
+      "text": "that"
+    },
+    {
+      "start": 1335.85,
+      "end": 1336.09,
+      "text": "we're"
+    },
+    {
+      "start": 1336.09,
+      "end": 1336.33,
+      "text": "probably"
+    },
+    {
+      "start": 1336.33,
+      "end": 1336.65,
+      "text": "keeping"
+    },
+    {
+      "start": 1336.64,
+      "end": 1336.8,
+      "text": "your"
+    },
+    {
+      "start": 1336.81,
+      "end": 1336.97,
+      "text": "data"
+    },
+    {
+      "start": 1336.96,
+      "end": 1337.44,
+      "text": "secure."
+    },
+    {
+      "start": 1337.45,
+      "end": 1337.69,
+      "text": "Whenever"
+    },
+    {
+      "start": 1337.68,
+      "end": 1337.84,
+      "text": "you"
+    },
+    {
+      "start": 1337.85,
+      "end": 1338.01,
+      "text": "move"
+    },
+    {
+      "start": 1338.01,
+      "end": 1338.17,
+      "text": "to"
+    },
+    {
+      "start": 1338.16,
+      "end": 1338.72,
+      "text": "another"
+    },
+    {
+      "start": 1339.13,
+      "end": 1339.69,
+      "text": "PDS"
+    },
+    {
+      "start": 1339.68,
+      "end": 1339.84,
+      "text": "or"
+    },
+    {
+      "start": 1339.85,
+      "end": 1340.17,
+      "text": "even"
+    },
+    {
+      "start": 1340.16,
+      "end": 1340.4,
+      "text": "self"
+    },
+    {
+      "start": 1340.4,
+      "end": 1341.04,
+      "text": "hosting,"
+    },
+    {
+      "start": 1341.05,
+      "end": 1341.13,
+      "text": "you"
+    },
+    {
+      "start": 1341.13,
+      "end": 1341.37,
+      "text": "take"
+    },
+    {
+      "start": 1341.37,
+      "end": 1341.53,
+      "text": "on"
+    },
+    {
+      "start": 1341.53,
+      "end": 1341.69,
+      "text": "some"
+    },
+    {
+      "start": 1341.68,
+      "end": 1342.08,
+      "text": "operational"
+    },
+    {
+      "start": 1342.09,
+      "end": 1342.73,
+      "text": "risk"
+    },
+    {
+      "start": 1342.62,
+      "end": 1342.94,
+      "text": "and"
+    },
+    {
+      "start": 1342.94,
+      "end": 1343.42,
+      "text": "having"
+    },
+    {
+      "start": 1343.42,
+      "end": 1343.66,
+      "text": "backup"
+    },
+    {
+      "start": 1343.66,
+      "end": 1343.9,
+      "text": "and"
+    },
+    {
+      "start": 1343.9,
+      "end": 1344.3,
+      "text": "recovery"
+    },
+    {
+      "start": 1344.3,
+      "end": 1344.94,
+      "text": "systems"
+    },
+    {
+      "start": 1344.94,
+      "end": 1345.34,
+      "text": "can"
+    },
+    {
+      "start": 1345.34,
+      "end": 1345.58,
+      "text": "give"
+    },
+    {
+      "start": 1345.58,
+      "end": 1345.74,
+      "text": "you"
+    },
+    {
+      "start": 1345.74,
+      "end": 1345.98,
+      "text": "peace"
+    },
+    {
+      "start": 1345.98,
+      "end": 1346.06,
+      "text": "of"
+    },
+    {
+      "start": 1346.06,
+      "end": 1346.38,
+      "text": "mind"
+    },
+    {
+      "start": 1346.38,
+      "end": 1346.7,
+      "text": "to"
+    },
+    {
+      "start": 1346.7,
+      "end": 1346.86,
+      "text": "do"
+    },
+    {
+      "start": 1346.86,
+      "end": 1347.34,
+      "text": "that."
+    },
+    {
+      "start": 1349.1,
+      "end": 1349.66,
+      "text": "The"
+    },
+    {
+      "start": 1350.54,
+      "end": 1350.7,
+      "text": "next"
+    },
+    {
+      "start": 1350.7,
+      "end": 1350.86,
+      "text": "thing"
+    },
+    {
+      "start": 1350.86,
+      "end": 1351.02,
+      "text": "that"
+    },
+    {
+      "start": 1351.02,
+      "end": 1351.1,
+      "text": "we"
+    },
+    {
+      "start": 1351.1,
+      "end": 1351.34,
+      "text": "called"
+    },
+    {
+      "start": 1351.34,
+      "end": 1351.5,
+      "text": "out"
+    },
+    {
+      "start": 1351.5,
+      "end": 1351.66,
+      "text": "was"
+    },
+    {
+      "start": 1351.66,
+      "end": 1352.06,
+      "text": "other"
+    },
+    {
+      "start": 1352.06,
+      "end": 1352.38,
+      "text": "data"
+    },
+    {
+      "start": 1352.38,
+      "end": 1352.7,
+      "text": "sources"
+    },
+    {
+      "start": 1352.7,
+      "end": 1353.02,
+      "text": "and"
+    },
+    {
+      "start": 1353.02,
+      "end": 1353.42,
+      "text": "backups"
+    },
+    {
+      "start": 1353.42,
+      "end": 1353.66,
+      "text": "for"
+    },
+    {
+      "start": 1353.66,
+      "end": 1354.78,
+      "text": "repositories."
+    },
+    {
+      "start": 1355.26,
+      "end": 1355.74,
+      "text": "Phil,"
+    },
+    {
+      "start": 1355.74,
+      "end": 1356.14,
+      "text": "Fig,"
+    },
+    {
+      "start": 1356.14,
+      "end": 1356.38,
+      "text": "bad"
+    },
+    {
+      "start": 1356.38,
+      "end": 1357.02,
+      "text": "example,"
+    },
+    {
+      "start": 1357.02,
+      "end": 1357.18,
+      "text": "just"
+    },
+    {
+      "start": 1357.18,
+      "end": 1357.5,
+      "text": "announced"
+    },
+    {
+      "start": 1357.5,
+      "end": 1357.98,
+      "text": "Hubble,"
+    },
+    {
+      "start": 1358.06,
+      "end": 1358.38,
+      "text": "which"
+    },
+    {
+      "start": 1358.38,
+      "end": 1358.54,
+      "text": "is"
+    },
+    {
+      "start": 1358.54,
+      "end": 1358.86,
+      "text": "funded"
+    },
+    {
+      "start": 1358.86,
+      "end": 1359.1,
+      "text": "via"
+    },
+    {
+      "start": 1359.1,
+      "end": 1359.26,
+      "text": "a"
+    },
+    {
+      "start": 1359.26,
+      "end": 1359.5,
+      "text": "grant"
+    },
+    {
+      "start": 1359.49,
+      "end": 1359.65,
+      "text": "from"
+    },
+    {
+      "start": 1359.65,
+      "end": 1359.89,
+      "text": "Blue"
+    },
+    {
+      "start": 1359.89,
+      "end": 1360.45,
+      "text": "Sky."
+    },
+    {
+      "start": 1360.54,
+      "end": 1360.78,
+      "text": "I'm"
+    },
+    {
+      "start": 1360.78,
+      "end": 1361.02,
+      "text": "super"
+    },
+    {
+      "start": 1361.02,
+      "end": 1361.34,
+      "text": "stoked"
+    },
+    {
+      "start": 1361.34,
+      "end": 1361.58,
+      "text": "about"
+    },
+    {
+      "start": 1361.58,
+      "end": 1361.74,
+      "text": "this"
+    },
+    {
+      "start": 1361.74,
+      "end": 1362.14,
+      "text": "project."
+    },
+    {
+      "start": 1362.13,
+      "end": 1362.53,
+      "text": "Hubble's"
+    },
+    {
+      "start": 1362.54,
+      "end": 1362.62,
+      "text": "a"
+    },
+    {
+      "start": 1362.62,
+      "end": 1362.78,
+      "text": "full"
+    },
+    {
+      "start": 1362.78,
+      "end": 1363.18,
+      "text": "network"
+    },
+    {
+      "start": 1363.17,
+      "end": 1363.57,
+      "text": "mirror"
+    },
+    {
+      "start": 1363.58,
+      "end": 1363.82,
+      "text": "of"
+    },
+    {
+      "start": 1363.82,
+      "end": 1364.14,
+      "text": "public"
+    },
+    {
+      "start": 1364.13,
+      "end": 1365.17,
+      "text": "repositories."
+    },
+    {
+      "start": 1365.26,
+      "end": 1365.34,
+      "text": "The"
+    },
+    {
+      "start": 1365.34,
+      "end": 1365.74,
+      "text": "Relay"
+    },
+    {
+      "start": 1365.74,
+      "end": 1365.98,
+      "text": "used"
+    },
+    {
+      "start": 1365.98,
+      "end": 1366.14,
+      "text": "to"
+    },
+    {
+      "start": 1366.13,
+      "end": 1366.37,
+      "text": "offer"
+    },
+    {
+      "start": 1366.38,
+      "end": 1366.62,
+      "text": "this"
+    },
+    {
+      "start": 1366.62,
+      "end": 1367.02,
+      "text": "whenever"
+    },
+    {
+      "start": 1367.02,
+      "end": 1367.26,
+      "text": "we"
+    },
+    {
+      "start": 1367.26,
+      "end": 1367.42,
+      "text": "switched"
+    },
+    {
+      "start": 1367.41,
+      "end": 1367.57,
+      "text": "to"
+    },
+    {
+      "start": 1367.58,
+      "end": 1367.82,
+      "text": "sync"
+    },
+    {
+      "start": 1367.82,
+      "end": 1368.54,
+      "text": "1.1."
+    },
+    {
+      "start": 1368.54,
+      "end": 1368.7,
+      "text": "It"
+    },
+    {
+      "start": 1368.7,
+      "end": 1368.94,
+      "text": "no"
+    },
+    {
+      "start": 1368.93,
+      "end": 1369.17,
+      "text": "longer"
+    },
+    {
+      "start": 1369.17,
+      "end": 1369.65,
+      "text": "mirrors"
+    },
+    {
+      "start": 1369.65,
+      "end": 1369.89,
+      "text": "all"
+    },
+    {
+      "start": 1369.89,
+      "end": 1370.13,
+      "text": "the"
+    },
+    {
+      "start": 1370.13,
+      "end": 1370.37,
+      "text": "public"
+    },
+    {
+      "start": 1370.38,
+      "end": 1370.94,
+      "text": "repositories"
+    },
+    {
+      "start": 1370.93,
+      "end": 1371.17,
+      "text": "in"
+    },
+    {
+      "start": 1371.17,
+      "end": 1371.25,
+      "text": "the"
+    },
+    {
+      "start": 1371.26,
+      "end": 1371.9,
+      "text": "network."
+    },
+    {
+      "start": 1372.62,
+      "end": 1372.7,
+      "text": "And"
+    },
+    {
+      "start": 1372.7,
+      "end": 1372.86,
+      "text": "so,"
+    },
+    {
+      "start": 1372.86,
+      "end": 1373.34,
+      "text": "this"
+    },
+    {
+      "start": 1373.83,
+      "end": 1374.31,
+      "text": "provides"
+    },
+    {
+      "start": 1374.31,
+      "end": 1374.47,
+      "text": "a"
+    },
+    {
+      "start": 1374.47,
+      "end": 1374.63,
+      "text": "full"
+    },
+    {
+      "start": 1374.63,
+      "end": 1375.11,
+      "text": "network"
+    },
+    {
+      "start": 1375.11,
+      "end": 1375.67,
+      "text": "copy"
+    },
+    {
+      "start": 1375.67,
+      "end": 1375.91,
+      "text": "of"
+    },
+    {
+      "start": 1375.91,
+      "end": 1376.07,
+      "text": "all"
+    },
+    {
+      "start": 1376.07,
+      "end": 1376.23,
+      "text": "of"
+    },
+    {
+      "start": 1376.23,
+      "end": 1376.31,
+      "text": "the"
+    },
+    {
+      "start": 1376.31,
+      "end": 1376.87,
+      "text": "data."
+    },
+    {
+      "start": 1376.95,
+      "end": 1377.19,
+      "text": "It's"
+    },
+    {
+      "start": 1377.19,
+      "end": 1377.51,
+      "text": "intended"
+    },
+    {
+      "start": 1377.51,
+      "end": 1377.67,
+      "text": "to"
+    },
+    {
+      "start": 1377.67,
+      "end": 1377.99,
+      "text": "increase"
+    },
+    {
+      "start": 1377.99,
+      "end": 1378.31,
+      "text": "network"
+    },
+    {
+      "start": 1378.31,
+      "end": 1379.03,
+      "text": "resilience."
+    },
+    {
+      "start": 1379.03,
+      "end": 1379.27,
+      "text": "This"
+    },
+    {
+      "start": 1379.27,
+      "end": 1379.35,
+      "text": "is"
+    },
+    {
+      "start": 1379.35,
+      "end": 1379.51,
+      "text": "a"
+    },
+    {
+      "start": 1379.51,
+      "end": 1379.75,
+      "text": "backup"
+    },
+    {
+      "start": 1379.75,
+      "end": 1379.91,
+      "text": "of"
+    },
+    {
+      "start": 1379.91,
+      "end": 1380.07,
+      "text": "your"
+    },
+    {
+      "start": 1380.07,
+      "end": 1380.87,
+      "text": "repository."
+    },
+    {
+      "start": 1381.11,
+      "end": 1381.35,
+      "text": "If"
+    },
+    {
+      "start": 1381.35,
+      "end": 1381.59,
+      "text": "your"
+    },
+    {
+      "start": 1381.59,
+      "end": 1382.07,
+      "text": "PDS"
+    },
+    {
+      "start": 1382.07,
+      "end": 1382.47,
+      "text": "crashes"
+    },
+    {
+      "start": 1382.47,
+      "end": 1382.63,
+      "text": "and"
+    },
+    {
+      "start": 1382.63,
+      "end": 1382.87,
+      "text": "burns"
+    },
+    {
+      "start": 1382.87,
+      "end": 1383.03,
+      "text": "and"
+    },
+    {
+      "start": 1383.03,
+      "end": 1383.11,
+      "text": "you"
+    },
+    {
+      "start": 1383.11,
+      "end": 1383.35,
+      "text": "lose"
+    },
+    {
+      "start": 1383.35,
+      "end": 1383.51,
+      "text": "your"
+    },
+    {
+      "start": 1383.51,
+      "end": 1384.23,
+      "text": "repository,"
+    },
+    {
+      "start": 1384.23,
+      "end": 1384.31,
+      "text": "you"
+    },
+    {
+      "start": 1384.31,
+      "end": 1384.39,
+      "text": "can"
+    },
+    {
+      "start": 1384.39,
+      "end": 1384.55,
+      "text": "go"
+    },
+    {
+      "start": 1384.55,
+      "end": 1384.71,
+      "text": "get"
+    },
+    {
+      "start": 1384.71,
+      "end": 1384.79,
+      "text": "it"
+    },
+    {
+      "start": 1384.79,
+      "end": 1384.95,
+      "text": "from"
+    },
+    {
+      "start": 1384.95,
+      "end": 1385.19,
+      "text": "here."
+    },
+    {
+      "start": 1385.19,
+      "end": 1385.27,
+      "text": "If"
+    },
+    {
+      "start": 1385.27,
+      "end": 1385.43,
+      "text": "Blue"
+    },
+    {
+      "start": 1385.43,
+      "end": 1385.59,
+      "text": "Sky"
+    },
+    {
+      "start": 1385.59,
+      "end": 1385.91,
+      "text": "tries"
+    },
+    {
+      "start": 1385.91,
+      "end": 1385.99,
+      "text": "to"
+    },
+    {
+      "start": 1385.99,
+      "end": 1386.15,
+      "text": "lock"
+    },
+    {
+      "start": 1386.15,
+      "end": 1386.31,
+      "text": "you"
+    },
+    {
+      "start": 1386.31,
+      "end": 1386.47,
+      "text": "out"
+    },
+    {
+      "start": 1386.47,
+      "end": 1386.55,
+      "text": "of"
+    },
+    {
+      "start": 1386.55,
+      "end": 1386.71,
+      "text": "it,"
+    },
+    {
+      "start": 1386.71,
+      "end": 1386.79,
+      "text": "you"
+    },
+    {
+      "start": 1386.79,
+      "end": 1386.95,
+      "text": "can"
+    },
+    {
+      "start": 1386.95,
+      "end": 1387.03,
+      "text": "go"
+    },
+    {
+      "start": 1387.03,
+      "end": 1387.19,
+      "text": "get"
+    },
+    {
+      "start": 1387.19,
+      "end": 1387.27,
+      "text": "a"
+    },
+    {
+      "start": 1387.27,
+      "end": 1387.51,
+      "text": "backup"
+    },
+    {
+      "start": 1387.51,
+      "end": 1387.67,
+      "text": "of"
+    },
+    {
+      "start": 1387.67,
+      "end": 1387.83,
+      "text": "your"
+    },
+    {
+      "start": 1387.83,
+      "end": 1388.31,
+      "text": "repository"
+    },
+    {
+      "start": 1388.31,
+      "end": 1388.63,
+      "text": "here."
+    },
+    {
+      "start": 1388.94,
+      "end": 1389.18,
+      "text": "Or"
+    },
+    {
+      "start": 1389.18,
+      "end": 1389.34,
+      "text": "if"
+    },
+    {
+      "start": 1389.35,
+      "end": 1389.51,
+      "text": "Blue"
+    },
+    {
+      "start": 1389.51,
+      "end": 1389.75,
+      "text": "Sky"
+    },
+    {
+      "start": 1389.74,
+      "end": 1389.98,
+      "text": "shuts"
+    },
+    {
+      "start": 1389.98,
+      "end": 1390.14,
+      "text": "down"
+    },
+    {
+      "start": 1390.14,
+      "end": 1390.3,
+      "text": "our"
+    },
+    {
+      "start": 1390.3,
+      "end": 1390.86,
+      "text": "APIs,"
+    },
+    {
+      "start": 1390.87,
+      "end": 1390.95,
+      "text": "then"
+    },
+    {
+      "start": 1390.94,
+      "end": 1391.02,
+      "text": "you"
+    },
+    {
+      "start": 1391.03,
+      "end": 1391.19,
+      "text": "can"
+    },
+    {
+      "start": 1391.18,
+      "end": 1391.34,
+      "text": "go"
+    },
+    {
+      "start": 1391.35,
+      "end": 1391.75,
+      "text": "sync"
+    },
+    {
+      "start": 1391.74,
+      "end": 1392.94,
+      "text": "repositories"
+    },
+    {
+      "start": 1392.94,
+      "end": 1393.26,
+      "text": "from"
+    },
+    {
+      "start": 1393.27,
+      "end": 1393.99,
+      "text": "Hubble."
+    },
+    {
+      "start": 1394.14,
+      "end": 1394.3,
+      "text": "All"
+    },
+    {
+      "start": 1394.3,
+      "end": 1394.46,
+      "text": "of"
+    },
+    {
+      "start": 1394.46,
+      "end": 1394.54,
+      "text": "the"
+    },
+    {
+      "start": 1394.55,
+      "end": 1394.71,
+      "text": "code"
+    },
+    {
+      "start": 1394.7,
+      "end": 1394.86,
+      "text": "will"
+    },
+    {
+      "start": 1394.87,
+      "end": 1395.03,
+      "text": "be"
+    },
+    {
+      "start": 1395.03,
+      "end": 1395.27,
+      "text": "open"
+    },
+    {
+      "start": 1395.27,
+      "end": 1395.51,
+      "text": "source"
+    },
+    {
+      "start": 1395.51,
+      "end": 1395.75,
+      "text": "and"
+    },
+    {
+      "start": 1395.74,
+      "end": 1396.3,
+      "text": "permissibly"
+    },
+    {
+      "start": 1396.3,
+      "end": 1396.94,
+      "text": "licensed."
+    },
+    {
+      "start": 1396.94,
+      "end": 1397.34,
+      "text": "Phil's"
+    },
+    {
+      "start": 1397.35,
+      "end": 1397.59,
+      "text": "planning"
+    },
+    {
+      "start": 1397.59,
+      "end": 1397.75,
+      "text": "on"
+    },
+    {
+      "start": 1397.74,
+      "end": 1398.06,
+      "text": "running"
+    },
+    {
+      "start": 1398.07,
+      "end": 1398.39,
+      "text": "an"
+    },
+    {
+      "start": 1398.38,
+      "end": 1398.7,
+      "text": "instance"
+    },
+    {
+      "start": 1398.7,
+      "end": 1398.86,
+      "text": "of"
+    },
+    {
+      "start": 1398.87,
+      "end": 1399.27,
+      "text": "this,"
+    },
+    {
+      "start": 1399.27,
+      "end": 1399.43,
+      "text": "but"
+    },
+    {
+      "start": 1399.42,
+      "end": 1399.82,
+      "text": "anybody"
+    },
+    {
+      "start": 1399.83,
+      "end": 1399.99,
+      "text": "can"
+    },
+    {
+      "start": 1399.98,
+      "end": 1400.14,
+      "text": "run"
+    },
+    {
+      "start": 1400.14,
+      "end": 1400.3,
+      "text": "an"
+    },
+    {
+      "start": 1400.3,
+      "end": 1400.62,
+      "text": "instance"
+    },
+    {
+      "start": 1400.63,
+      "end": 1400.79,
+      "text": "of"
+    },
+    {
+      "start": 1400.79,
+      "end": 1400.95,
+      "text": "this"
+    },
+    {
+      "start": 1400.94,
+      "end": 1401.1,
+      "text": "and"
+    },
+    {
+      "start": 1401.11,
+      "end": 1401.43,
+      "text": "provide"
+    },
+    {
+      "start": 1401.42,
+      "end": 1401.5,
+      "text": "a"
+    },
+    {
+      "start": 1401.51,
+      "end": 1401.67,
+      "text": "full"
+    },
+    {
+      "start": 1401.66,
+      "end": 1402.06,
+      "text": "network"
+    },
+    {
+      "start": 1402.07,
+      "end": 1402.39,
+      "text": "mirror."
+    },
+    {
+      "start": 1404.64,
+      "end": 1405.12,
+      "text": "Consumer"
+    },
+    {
+      "start": 1405.12,
+      "end": 1405.36,
+      "text": "key"
+    },
+    {
+      "start": 1405.36,
+      "end": 1405.84,
+      "text": "management"
+    },
+    {
+      "start": 1405.84,
+      "end": 1406.08,
+      "text": "and"
+    },
+    {
+      "start": 1406.08,
+      "end": 1406.48,
+      "text": "recovery"
+    },
+    {
+      "start": 1406.48,
+      "end": 1406.96,
+      "text": "tools."
+    },
+    {
+      "start": 1406.96,
+      "end": 1407.04,
+      "text": "I"
+    },
+    {
+      "start": 1407.04,
+      "end": 1407.2,
+      "text": "actually"
+    },
+    {
+      "start": 1407.2,
+      "end": 1407.36,
+      "text": "think"
+    },
+    {
+      "start": 1407.36,
+      "end": 1407.52,
+      "text": "that"
+    },
+    {
+      "start": 1407.52,
+      "end": 1407.76,
+      "text": "there's"
+    },
+    {
+      "start": 1407.76,
+      "end": 1407.92,
+      "text": "a"
+    },
+    {
+      "start": 1407.92,
+      "end": 1408.08,
+      "text": "really"
+    },
+    {
+      "start": 1408.08,
+      "end": 1408.32,
+      "text": "great"
+    },
+    {
+      "start": 1408.32,
+      "end": 1408.64,
+      "text": "product"
+    },
+    {
+      "start": 1408.64,
+      "end": 1409.04,
+      "text": "opportunity"
+    },
+    {
+      "start": 1409.04,
+      "end": 1409.28,
+      "text": "here"
+    },
+    {
+      "start": 1409.28,
+      "end": 1409.44,
+      "text": "and"
+    },
+    {
+      "start": 1409.44,
+      "end": 1409.68,
+      "text": "I'm"
+    },
+    {
+      "start": 1409.68,
+      "end": 1409.76,
+      "text": "kind"
+    },
+    {
+      "start": 1409.76,
+      "end": 1409.92,
+      "text": "of"
+    },
+    {
+      "start": 1409.92,
+      "end": 1410.16,
+      "text": "surprised"
+    },
+    {
+      "start": 1410.16,
+      "end": 1410.4,
+      "text": "that"
+    },
+    {
+      "start": 1410.4,
+      "end": 1410.72,
+      "text": "nobody's"
+    },
+    {
+      "start": 1410.72,
+      "end": 1410.88,
+      "text": "done"
+    },
+    {
+      "start": 1410.88,
+      "end": 1411.28,
+      "text": "it."
+    },
+    {
+      "start": 1411.28,
+      "end": 1411.44,
+      "text": "You"
+    },
+    {
+      "start": 1411.44,
+      "end": 1411.52,
+      "text": "can"
+    },
+    {
+      "start": 1411.52,
+      "end": 1411.76,
+      "text": "take"
+    },
+    {
+      "start": 1411.76,
+      "end": 1412.08,
+      "text": "advantage"
+    },
+    {
+      "start": 1412.08,
+      "end": 1412.32,
+      "text": "of"
+    },
+    {
+      "start": 1412.32,
+      "end": 1412.56,
+      "text": "phone"
+    },
+    {
+      "start": 1412.56,
+      "end": 1413.2,
+      "text": "TPMs"
+    },
+    {
+      "start": 1413.2,
+      "end": 1413.36,
+      "text": "for"
+    },
+    {
+      "start": 1413.36,
+      "end": 1413.92,
+      "text": "restoring"
+    },
+    {
+      "start": 1413.92,
+      "end": 1414.48,
+      "text": "recovery"
+    },
+    {
+      "start": 1414.48,
+      "end": 1414.72,
+      "text": "keys"
+    },
+    {
+      "start": 1414.72,
+      "end": 1414.96,
+      "text": "in"
+    },
+    {
+      "start": 1414.96,
+      "end": 1415.04,
+      "text": "a"
+    },
+    {
+      "start": 1415.04,
+      "end": 1415.28,
+      "text": "very"
+    },
+    {
+      "start": 1415.28,
+      "end": 1415.6,
+      "text": "secure"
+    },
+    {
+      "start": 1415.6,
+      "end": 1415.76,
+      "text": "way."
+    },
+    {
+      "start": 1416.53,
+      "end": 1416.85,
+      "text": "This"
+    },
+    {
+      "start": 1416.85,
+      "end": 1417.33,
+      "text": "application"
+    },
+    {
+      "start": 1417.33,
+      "end": 1417.57,
+      "text": "could"
+    },
+    {
+      "start": 1417.57,
+      "end": 1417.81,
+      "text": "also"
+    },
+    {
+      "start": 1417.81,
+      "end": 1418.29,
+      "text": "audit"
+    },
+    {
+      "start": 1418.29,
+      "end": 1418.85,
+      "text": "PLC"
+    },
+    {
+      "start": 1418.85,
+      "end": 1419.09,
+      "text": "and"
+    },
+    {
+      "start": 1419.09,
+      "end": 1419.49,
+      "text": "notify"
+    },
+    {
+      "start": 1419.48,
+      "end": 1419.8,
+      "text": "users"
+    },
+    {
+      "start": 1419.81,
+      "end": 1420.05,
+      "text": "of"
+    },
+    {
+      "start": 1420.05,
+      "end": 1420.29,
+      "text": "any"
+    },
+    {
+      "start": 1420.29,
+      "end": 1420.77,
+      "text": "unexpected"
+    },
+    {
+      "start": 1420.77,
+      "end": 1421.65,
+      "text": "operations"
+    },
+    {
+      "start": 1421.88,
+      "end": 1422.2,
+      "text": "and"
+    },
+    {
+      "start": 1422.21,
+      "end": 1422.37,
+      "text": "I"
+    },
+    {
+      "start": 1422.61,
+      "end": 1422.85,
+      "text": "just"
+    },
+    {
+      "start": 1422.85,
+      "end": 1422.93,
+      "text": "to"
+    },
+    {
+      "start": 1422.92,
+      "end": 1423.16,
+      "text": "note,"
+    },
+    {
+      "start": 1423.16,
+      "end": 1423.24,
+      "text": "I"
+    },
+    {
+      "start": 1423.24,
+      "end": 1423.48,
+      "text": "also"
+    },
+    {
+      "start": 1423.48,
+      "end": 1423.64,
+      "text": "think"
+    },
+    {
+      "start": 1423.64,
+      "end": 1423.72,
+      "text": "that"
+    },
+    {
+      "start": 1423.73,
+      "end": 1423.89,
+      "text": "this"
+    },
+    {
+      "start": 1423.88,
+      "end": 1424.04,
+      "text": "would"
+    },
+    {
+      "start": 1424.05,
+      "end": 1424.45,
+      "text": "partner"
+    },
+    {
+      "start": 1424.45,
+      "end": 1424.69,
+      "text": "well"
+    },
+    {
+      "start": 1424.68,
+      "end": 1424.92,
+      "text": "with"
+    },
+    {
+      "start": 1424.92,
+      "end": 1425.08,
+      "text": "a"
+    },
+    {
+      "start": 1425.09,
+      "end": 1425.33,
+      "text": "backup"
+    },
+    {
+      "start": 1425.33,
+      "end": 1425.57,
+      "text": "or"
+    },
+    {
+      "start": 1425.57,
+      "end": 1426.05,
+      "text": "recovery"
+    },
+    {
+      "start": 1426.05,
+      "end": 1426.53,
+      "text": "service"
+    },
+    {
+      "start": 1426.53,
+      "end": 1426.93,
+      "text": "especially"
+    },
+    {
+      "start": 1426.92,
+      "end": 1427.24,
+      "text": "whenever"
+    },
+    {
+      "start": 1427.24,
+      "end": 1427.48,
+      "text": "we"
+    },
+    {
+      "start": 1427.48,
+      "end": 1427.64,
+      "text": "put"
+    },
+    {
+      "start": 1427.64,
+      "end": 1427.8,
+      "text": "out"
+    },
+    {
+      "start": 1427.81,
+      "end": 1428.29,
+      "text": "permission"
+    },
+    {
+      "start": 1428.29,
+      "end": 1428.69,
+      "text": "data."
+    },
+    {
+      "start": 1430.71,
+      "end": 1431.03,
+      "text": "And"
+    },
+    {
+      "start": 1431.03,
+      "end": 1431.27,
+      "text": "then,"
+    },
+    {
+      "start": 1431.27,
+      "end": 1431.35,
+      "text": "the"
+    },
+    {
+      "start": 1431.35,
+      "end": 1431.59,
+      "text": "final"
+    },
+    {
+      "start": 1431.59,
+      "end": 1431.75,
+      "text": "thing"
+    },
+    {
+      "start": 1431.75,
+      "end": 1431.91,
+      "text": "is"
+    },
+    {
+      "start": 1431.91,
+      "end": 1432.07,
+      "text": "just"
+    },
+    {
+      "start": 1432.07,
+      "end": 1432.23,
+      "text": "a"
+    },
+    {
+      "start": 1432.23,
+      "end": 1432.55,
+      "text": "thriving"
+    },
+    {
+      "start": 1432.55,
+      "end": 1433.03,
+      "text": "ecosystem"
+    },
+    {
+      "start": 1433.03,
+      "end": 1433.35,
+      "text": "built"
+    },
+    {
+      "start": 1433.35,
+      "end": 1433.51,
+      "text": "on"
+    },
+    {
+      "start": 1433.51,
+      "end": 1433.75,
+      "text": "open"
+    },
+    {
+      "start": 1433.75,
+      "end": 1434.15,
+      "text": "data."
+    },
+    {
+      "start": 1434.15,
+      "end": 1434.23,
+      "text": "And"
+    },
+    {
+      "start": 1434.23,
+      "end": 1434.39,
+      "text": "this"
+    },
+    {
+      "start": 1434.39,
+      "end": 1434.55,
+      "text": "is"
+    },
+    {
+      "start": 1434.55,
+      "end": 1434.71,
+      "text": "I"
+    },
+    {
+      "start": 1434.71,
+      "end": 1434.79,
+      "text": "think"
+    },
+    {
+      "start": 1434.79,
+      "end": 1434.95,
+      "text": "the"
+    },
+    {
+      "start": 1434.95,
+      "end": 1435.19,
+      "text": "biggest"
+    },
+    {
+      "start": 1435.19,
+      "end": 1435.35,
+      "text": "part"
+    },
+    {
+      "start": 1435.35,
+      "end": 1435.59,
+      "text": "where"
+    },
+    {
+      "start": 1435.59,
+      "end": 1435.67,
+      "text": "you"
+    },
+    {
+      "start": 1435.67,
+      "end": 1435.83,
+      "text": "all"
+    },
+    {
+      "start": 1435.83,
+      "end": 1435.99,
+      "text": "come"
+    },
+    {
+      "start": 1435.99,
+      "end": 1436.47,
+      "text": "in."
+    },
+    {
+      "start": 1436.63,
+      "end": 1437.03,
+      "text": "Apps"
+    },
+    {
+      "start": 1437.03,
+      "end": 1437.27,
+      "text": "built"
+    },
+    {
+      "start": 1437.27,
+      "end": 1437.43,
+      "text": "on"
+    },
+    {
+      "start": 1437.43,
+      "end": 1437.59,
+      "text": "the"
+    },
+    {
+      "start": 1437.59,
+      "end": 1438.15,
+      "text": "atmosphere,"
+    },
+    {
+      "start": 1438.15,
+      "end": 1438.71,
+      "text": "atmospheric"
+    },
+    {
+      "start": 1438.71,
+      "end": 1439.43,
+      "text": "websites,"
+    },
+    {
+      "start": 1439.43,
+      "end": 1439.91,
+      "text": "feeds,"
+    },
+    {
+      "start": 1439.91,
+      "end": 1440.39,
+      "text": "labelers,"
+    },
+    {
+      "start": 1440.39,
+      "end": 1440.63,
+      "text": "social"
+    },
+    {
+      "start": 1440.63,
+      "end": 1440.95,
+      "text": "media"
+    },
+    {
+      "start": 1440.95,
+      "end": 1441.51,
+      "text": "tools,"
+    },
+    {
+      "start": 1441.51,
+      "end": 1441.83,
+      "text": "anything"
+    },
+    {
+      "start": 1441.83,
+      "end": 1442.07,
+      "text": "that"
+    },
+    {
+      "start": 1442.07,
+      "end": 1442.71,
+      "text": "requires"
+    },
+    {
+      "start": 1442.71,
+      "end": 1442.95,
+      "text": "that"
+    },
+    {
+      "start": 1442.95,
+      "end": 1443.11,
+      "text": "the"
+    },
+    {
+      "start": 1443.11,
+      "end": 1443.27,
+      "text": "data"
+    },
+    {
+      "start": 1443.27,
+      "end": 1443.51,
+      "text": "be"
+    },
+    {
+      "start": 1443.51,
+      "end": 1444.07,
+      "text": "open."
+    },
+    {
+      "start": 1444.15,
+      "end": 1444.39,
+      "text": "In"
+    },
+    {
+      "start": 1444.39,
+      "end": 1444.55,
+      "text": "some"
+    },
+    {
+      "start": 1444.55,
+      "end": 1444.79,
+      "text": "sense,"
+    },
+    {
+      "start": 1445.04,
+      "end": 1445.28,
+      "text": "all"
+    },
+    {
+      "start": 1445.28,
+      "end": 1445.44,
+      "text": "of"
+    },
+    {
+      "start": 1445.44,
+      "end": 1445.52,
+      "text": "the"
+    },
+    {
+      "start": 1445.53,
+      "end": 1445.93,
+      "text": "previous"
+    },
+    {
+      "start": 1445.92,
+      "end": 1446.24,
+      "text": "threats"
+    },
+    {
+      "start": 1446.24,
+      "end": 1446.4,
+      "text": "that"
+    },
+    {
+      "start": 1446.4,
+      "end": 1446.48,
+      "text": "we"
+    },
+    {
+      "start": 1446.48,
+      "end": 1446.8,
+      "text": "talked"
+    },
+    {
+      "start": 1446.8,
+      "end": 1447.12,
+      "text": "about"
+    },
+    {
+      "start": 1447.13,
+      "end": 1447.77,
+      "text": "are"
+    },
+    {
+      "start": 1448.57,
+      "end": 1448.81,
+      "text": "they're"
+    },
+    {
+      "start": 1448.8,
+      "end": 1448.96,
+      "text": "pretty"
+    },
+    {
+      "start": 1448.96,
+      "end": 1449.44,
+      "text": "protocol"
+    },
+    {
+      "start": 1449.44,
+      "end": 1449.92,
+      "text": "brained,"
+    },
+    {
+      "start": 1449.92,
+      "end": 1450,
+      "text": "and"
+    },
+    {
+      "start": 1450.01,
+      "end": 1450.17,
+      "text": "I"
+    },
+    {
+      "start": 1450.16,
+      "end": 1450.32,
+      "text": "just"
+    },
+    {
+      "start": 1450.33,
+      "end": 1450.57,
+      "text": "don't"
+    },
+    {
+      "start": 1450.57,
+      "end": 1450.73,
+      "text": "think"
+    },
+    {
+      "start": 1450.72,
+      "end": 1450.8,
+      "text": "a"
+    },
+    {
+      "start": 1450.8,
+      "end": 1450.96,
+      "text": "lot"
+    },
+    {
+      "start": 1450.96,
+      "end": 1451.04,
+      "text": "of"
+    },
+    {
+      "start": 1451.04,
+      "end": 1451.36,
+      "text": "users"
+    },
+    {
+      "start": 1451.37,
+      "end": 1451.53,
+      "text": "are"
+    },
+    {
+      "start": 1451.53,
+      "end": 1451.69,
+      "text": "going"
+    },
+    {
+      "start": 1451.68,
+      "end": 1451.84,
+      "text": "to"
+    },
+    {
+      "start": 1451.85,
+      "end": 1452.01,
+      "text": "care"
+    },
+    {
+      "start": 1452.01,
+      "end": 1452.33,
+      "text": "or"
+    },
+    {
+      "start": 1452.33,
+      "end": 1452.65,
+      "text": "engage"
+    },
+    {
+      "start": 1452.64,
+      "end": 1452.88,
+      "text": "about"
+    },
+    {
+      "start": 1452.88,
+      "end": 1453.12,
+      "text": "that."
+    },
+    {
+      "start": 1453.13,
+      "end": 1453.29,
+      "text": "And"
+    },
+    {
+      "start": 1453.28,
+      "end": 1453.36,
+      "text": "I"
+    },
+    {
+      "start": 1453.37,
+      "end": 1453.53,
+      "text": "don't"
+    },
+    {
+      "start": 1453.53,
+      "end": 1453.69,
+      "text": "think"
+    },
+    {
+      "start": 1453.68,
+      "end": 1453.84,
+      "text": "that"
+    },
+    {
+      "start": 1453.85,
+      "end": 1454.01,
+      "text": "we're"
+    },
+    {
+      "start": 1454.01,
+      "end": 1454.17,
+      "text": "going"
+    },
+    {
+      "start": 1454.16,
+      "end": 1454.24,
+      "text": "to"
+    },
+    {
+      "start": 1454.24,
+      "end": 1454.32,
+      "text": "get"
+    },
+    {
+      "start": 1454.33,
+      "end": 1454.49,
+      "text": "to"
+    },
+    {
+      "start": 1454.48,
+      "end": 1454.64,
+      "text": "like"
+    },
+    {
+      "start": 1454.64,
+      "end": 1454.88,
+      "text": "an"
+    },
+    {
+      "start": 1454.88,
+      "end": 1455.12,
+      "text": "even"
+    },
+    {
+      "start": 1455.13,
+      "end": 1455.69,
+      "text": "distribution"
+    },
+    {
+      "start": 1455.68,
+      "end": 1455.84,
+      "text": "of"
+    },
+    {
+      "start": 1455.85,
+      "end": 1456.41,
+      "text": "users"
+    },
+    {
+      "start": 1456.4,
+      "end": 1456.72,
+      "text": "by"
+    },
+    {
+      "start": 1456.72,
+      "end": 1457.2,
+      "text": "focusing"
+    },
+    {
+      "start": 1457.2,
+      "end": 1457.68,
+      "text": "on"
+    },
+    {
+      "start": 1457.92,
+      "end": 1458.16,
+      "text": "key"
+    },
+    {
+      "start": 1458.16,
+      "end": 1458.56,
+      "text": "recovery"
+    },
+    {
+      "start": 1458.57,
+      "end": 1458.81,
+      "text": "or"
+    },
+    {
+      "start": 1458.8,
+      "end": 1458.96,
+      "text": "non"
+    },
+    {
+      "start": 1458.96,
+      "end": 1459.2,
+      "text": "blue"
+    },
+    {
+      "start": 1459.2,
+      "end": 1459.36,
+      "text": "sky"
+    },
+    {
+      "start": 1459.37,
+      "end": 1459.93,
+      "text": "PDSs"
+    },
+    {
+      "start": 1459.92,
+      "end": 1460.16,
+      "text": "or"
+    },
+    {
+      "start": 1460.16,
+      "end": 1460.4,
+      "text": "anything"
+    },
+    {
+      "start": 1460.4,
+      "end": 1460.64,
+      "text": "like"
+    },
+    {
+      "start": 1460.64,
+      "end": 1460.72,
+      "text": "that."
+    },
+    {
+      "start": 1461.02,
+      "end": 1461.26,
+      "text": "The"
+    },
+    {
+      "start": 1461.26,
+      "end": 1461.58,
+      "text": "most"
+    },
+    {
+      "start": 1461.58,
+      "end": 1462.06,
+      "text": "important"
+    },
+    {
+      "start": 1462.06,
+      "end": 1462.3,
+      "text": "thing"
+    },
+    {
+      "start": 1462.3,
+      "end": 1462.46,
+      "text": "for"
+    },
+    {
+      "start": 1462.46,
+      "end": 1462.62,
+      "text": "the"
+    },
+    {
+      "start": 1462.62,
+      "end": 1462.94,
+      "text": "resilience"
+    },
+    {
+      "start": 1462.94,
+      "end": 1463.18,
+      "text": "of"
+    },
+    {
+      "start": 1463.18,
+      "end": 1463.26,
+      "text": "the"
+    },
+    {
+      "start": 1463.26,
+      "end": 1463.74,
+      "text": "network"
+    },
+    {
+      "start": 1463.74,
+      "end": 1463.9,
+      "text": "is"
+    },
+    {
+      "start": 1463.9,
+      "end": 1464.38,
+      "text": "that"
+    },
+    {
+      "start": 1464.38,
+      "end": 1464.7,
+      "text": "users"
+    },
+    {
+      "start": 1464.7,
+      "end": 1465.02,
+      "text": "need"
+    },
+    {
+      "start": 1465.02,
+      "end": 1465.1,
+      "text": "to"
+    },
+    {
+      "start": 1465.1,
+      "end": 1465.42,
+      "text": "understand"
+    },
+    {
+      "start": 1465.42,
+      "end": 1465.58,
+      "text": "that"
+    },
+    {
+      "start": 1465.58,
+      "end": 1465.82,
+      "text": "they're"
+    },
+    {
+      "start": 1465.82,
+      "end": 1466.22,
+      "text": "participating"
+    },
+    {
+      "start": 1466.22,
+      "end": 1466.46,
+      "text": "in"
+    },
+    {
+      "start": 1466.46,
+      "end": 1466.54,
+      "text": "a"
+    },
+    {
+      "start": 1466.54,
+      "end": 1466.78,
+      "text": "multi"
+    },
+    {
+      "start": 1466.78,
+      "end": 1467.18,
+      "text": "stakeholder"
+    },
+    {
+      "start": 1467.18,
+      "end": 1467.82,
+      "text": "network."
+    },
+    {
+      "start": 1467.82,
+      "end": 1467.98,
+      "text": "That"
+    },
+    {
+      "start": 1467.98,
+      "end": 1468.14,
+      "text": "they're"
+    },
+    {
+      "start": 1468.14,
+      "end": 1468.62,
+      "text": "participating"
+    },
+    {
+      "start": 1468.62,
+      "end": 1468.78,
+      "text": "in"
+    },
+    {
+      "start": 1468.78,
+      "end": 1468.94,
+      "text": "the"
+    },
+    {
+      "start": 1468.94,
+      "end": 1469.66,
+      "text": "atmosphere,"
+    },
+    {
+      "start": 1469.66,
+      "end": 1469.82,
+      "text": "that"
+    },
+    {
+      "start": 1469.82,
+      "end": 1469.98,
+      "text": "they're"
+    },
+    {
+      "start": 1469.98,
+      "end": 1470.14,
+      "text": "not"
+    },
+    {
+      "start": 1470.14,
+      "end": 1470.7,
+      "text": "participating"
+    },
+    {
+      "start": 1470.7,
+      "end": 1470.86,
+      "text": "in"
+    },
+    {
+      "start": 1470.86,
+      "end": 1471.1,
+      "text": "blue"
+    },
+    {
+      "start": 1471.1,
+      "end": 1471.66,
+      "text": "sky."
+    },
+    {
+      "start": 1471.66,
+      "end": 1471.74,
+      "text": "And"
+    },
+    {
+      "start": 1471.74,
+      "end": 1471.9,
+      "text": "so,"
+    },
+    {
+      "start": 1471.9,
+      "end": 1472.06,
+      "text": "if"
+    },
+    {
+      "start": 1472.06,
+      "end": 1472.22,
+      "text": "we're"
+    },
+    {
+      "start": 1472.22,
+      "end": 1472.54,
+      "text": "building"
+    },
+    {
+      "start": 1472.54,
+      "end": 1472.94,
+      "text": "things"
+    },
+    {
+      "start": 1473.13,
+      "end": 1473.45,
+      "text": "that"
+    },
+    {
+      "start": 1473.45,
+      "end": 1473.69,
+      "text": "run"
+    },
+    {
+      "start": 1473.7,
+      "end": 1473.94,
+      "text": "on"
+    },
+    {
+      "start": 1473.93,
+      "end": 1474.17,
+      "text": "open"
+    },
+    {
+      "start": 1474.17,
+      "end": 1474.41,
+      "text": "data"
+    },
+    {
+      "start": 1474.41,
+      "end": 1474.73,
+      "text": "and"
+    },
+    {
+      "start": 1474.73,
+      "end": 1475.05,
+      "text": "users"
+    },
+    {
+      "start": 1475.06,
+      "end": 1475.46,
+      "text": "fall"
+    },
+    {
+      "start": 1475.45,
+      "end": 1475.61,
+      "text": "in"
+    },
+    {
+      "start": 1475.62,
+      "end": 1476.02,
+      "text": "love"
+    },
+    {
+      "start": 1476.02,
+      "end": 1476.34,
+      "text": "with"
+    },
+    {
+      "start": 1476.34,
+      "end": 1477.38,
+      "text": "OpenSocial"
+    },
+    {
+      "start": 1477.38,
+      "end": 1477.62,
+      "text": "and"
+    },
+    {
+      "start": 1477.62,
+      "end": 1477.86,
+      "text": "these"
+    },
+    {
+      "start": 1477.86,
+      "end": 1478.34,
+      "text": "experiences"
+    },
+    {
+      "start": 1478.34,
+      "end": 1478.66,
+      "text": "that"
+    },
+    {
+      "start": 1478.65,
+      "end": 1478.73,
+      "text": "you"
+    },
+    {
+      "start": 1478.73,
+      "end": 1478.89,
+      "text": "can"
+    },
+    {
+      "start": 1478.89,
+      "end": 1479.21,
+      "text": "only"
+    },
+    {
+      "start": 1479.21,
+      "end": 1479.45,
+      "text": "build"
+    },
+    {
+      "start": 1479.45,
+      "end": 1479.69,
+      "text": "on"
+    },
+    {
+      "start": 1479.7,
+      "end": 1480.02,
+      "text": "open"
+    },
+    {
+      "start": 1480.02,
+      "end": 1480.5,
+      "text": "data,"
+    },
+    {
+      "start": 1480.49,
+      "end": 1480.65,
+      "text": "that"
+    },
+    {
+      "start": 1480.65,
+      "end": 1480.89,
+      "text": "is"
+    },
+    {
+      "start": 1480.89,
+      "end": 1481.05,
+      "text": "the"
+    },
+    {
+      "start": 1481.06,
+      "end": 1481.38,
+      "text": "most"
+    },
+    {
+      "start": 1481.38,
+      "end": 1481.78,
+      "text": "important"
+    },
+    {
+      "start": 1481.78,
+      "end": 1482.02,
+      "text": "thing"
+    },
+    {
+      "start": 1482.02,
+      "end": 1482.18,
+      "text": "that"
+    },
+    {
+      "start": 1482.17,
+      "end": 1482.33,
+      "text": "we"
+    },
+    {
+      "start": 1482.34,
+      "end": 1482.5,
+      "text": "can"
+    },
+    {
+      "start": 1482.49,
+      "end": 1482.73,
+      "text": "do"
+    },
+    {
+      "start": 1482.73,
+      "end": 1483.05,
+      "text": "to"
+    },
+    {
+      "start": 1483.06,
+      "end": 1483.22,
+      "text": "keep"
+    },
+    {
+      "start": 1483.21,
+      "end": 1483.45,
+      "text": "Blue"
+    },
+    {
+      "start": 1483.45,
+      "end": 1483.69,
+      "text": "Sky"
+    },
+    {
+      "start": 1483.7,
+      "end": 1484.1,
+      "text": "honest"
+    },
+    {
+      "start": 1484.1,
+      "end": 1484.42,
+      "text": "and"
+    },
+    {
+      "start": 1484.41,
+      "end": 1484.73,
+      "text": "to"
+    },
+    {
+      "start": 1484.73,
+      "end": 1485.13,
+      "text": "keep"
+    },
+    {
+      "start": 1485.13,
+      "end": 1485.29,
+      "text": "the"
+    },
+    {
+      "start": 1485.3,
+      "end": 1485.78,
+      "text": "OpenSocial"
+    },
+    {
+      "start": 1485.78,
+      "end": 1486.02,
+      "text": "web"
+    },
+    {
+      "start": 1486.02,
+      "end": 1486.34,
+      "text": "running."
+    },
+    {
+      "start": 1487.26,
+      "end": 1487.74,
+      "text": "So,"
+    },
+    {
+      "start": 1487.74,
+      "end": 1487.82,
+      "text": "the"
+    },
+    {
+      "start": 1487.82,
+      "end": 1487.98,
+      "text": "best"
+    },
+    {
+      "start": 1487.98,
+      "end": 1488.22,
+      "text": "way"
+    },
+    {
+      "start": 1488.22,
+      "end": 1488.38,
+      "text": "to"
+    },
+    {
+      "start": 1488.38,
+      "end": 1488.62,
+      "text": "ensure"
+    },
+    {
+      "start": 1488.62,
+      "end": 1488.78,
+      "text": "the"
+    },
+    {
+      "start": 1488.78,
+      "end": 1489.26,
+      "text": "resilience"
+    },
+    {
+      "start": 1489.26,
+      "end": 1489.5,
+      "text": "of"
+    },
+    {
+      "start": 1489.5,
+      "end": 1489.66,
+      "text": "the"
+    },
+    {
+      "start": 1489.66,
+      "end": 1489.98,
+      "text": "network"
+    },
+    {
+      "start": 1489.98,
+      "end": 1490.3,
+      "text": "is"
+    },
+    {
+      "start": 1490.3,
+      "end": 1490.46,
+      "text": "to"
+    },
+    {
+      "start": 1490.46,
+      "end": 1490.62,
+      "text": "build"
+    },
+    {
+      "start": 1490.62,
+      "end": 1490.94,
+      "text": "something"
+    },
+    {
+      "start": 1490.94,
+      "end": 1491.1,
+      "text": "that"
+    },
+    {
+      "start": 1491.1,
+      "end": 1491.26,
+      "text": "people"
+    },
+    {
+      "start": 1491.26,
+      "end": 1491.58,
+      "text": "love"
+    },
+    {
+      "start": 1491.58,
+      "end": 1491.98,
+      "text": "so"
+    },
+    {
+      "start": 1491.98,
+      "end": 1492.22,
+      "text": "much"
+    },
+    {
+      "start": 1492.22,
+      "end": 1492.54,
+      "text": "that"
+    },
+    {
+      "start": 1492.54,
+      "end": 1492.7,
+      "text": "they"
+    },
+    {
+      "start": 1492.7,
+      "end": 1492.86,
+      "text": "would"
+    },
+    {
+      "start": 1492.86,
+      "end": 1493.18,
+      "text": "revolt"
+    },
+    {
+      "start": 1493.18,
+      "end": 1493.42,
+      "text": "if"
+    },
+    {
+      "start": 1493.42,
+      "end": 1493.5,
+      "text": "it"
+    },
+    {
+      "start": 1493.5,
+      "end": 1493.66,
+      "text": "went"
+    },
+    {
+      "start": 1493.74,
+      "end": 1493.9,
+      "text": "if"
+    },
+    {
+      "start": 1493.9,
+      "end": 1494.06,
+      "text": "it"
+    },
+    {
+      "start": 1494.06,
+      "end": 1494.3,
+      "text": "ever"
+    },
+    {
+      "start": 1494.3,
+      "end": 1494.46,
+      "text": "went"
+    },
+    {
+      "start": 1494.46,
+      "end": 1495.02,
+      "text": "away."
+    },
+    {
+      "start": 1497.18,
+      "end": 1497.58,
+      "text": "Sweet."
+    },
+    {
+      "start": 1497.58,
+      "end": 1497.74,
+      "text": "Thank"
+    },
+    {
+      "start": 1497.74,
+      "end": 1497.82,
+      "text": "you."
+    },
+    {
+      "start": 1506.07,
+      "end": 1506.71,
+      "text": "We're"
+    },
+    {
+      "start": 1507.35,
+      "end": 1507.75,
+      "text": "that's"
+    },
+    {
+      "start": 1507.74,
+      "end": 1507.98,
+      "text": "great."
+    },
+    {
+      "start": 1507.98,
+      "end": 1508.22,
+      "text": "It's"
+    },
+    {
+      "start": 1508.23,
+      "end": 1508.87,
+      "text": "awesome."
+    },
+    {
+      "start": 1509.51,
+      "end": 1509.67,
+      "text": "We"
+    },
+    {
+      "start": 1509.66,
+      "end": 1509.9,
+      "text": "should"
+    },
+    {
+      "start": 1509.9,
+      "end": 1510.06,
+      "text": "get"
+    },
+    {
+      "start": 1510.07,
+      "end": 1510.39,
+      "text": "that"
+    },
+    {
+      "start": 1510.38,
+      "end": 1510.62,
+      "text": "done"
+    },
+    {
+      "start": 1510.63,
+      "end": 1510.95,
+      "text": "probably"
+    },
+    {
+      "start": 1510.95,
+      "end": 1511.51,
+      "text": "by"
+    },
+    {
+      "start": 1511.59,
+      "end": 1511.91,
+      "text": "next"
+    },
+    {
+      "start": 1511.9,
+      "end": 1512.22,
+      "text": "week,"
+    },
+    {
+      "start": 1512.23,
+      "end": 1512.39,
+      "text": "week"
+    },
+    {
+      "start": 1512.38,
+      "end": 1512.62,
+      "text": "after"
+    },
+    {
+      "start": 1512.63,
+      "end": 1512.95,
+      "text": "next."
+    },
+    {
+      "start": 1512.95,
+      "end": 1513.03,
+      "text": "So"
+    },
+    {
+      "start": 1513.03,
+      "end": 1513.35,
+      "text": "it's"
+    },
+    {
+      "start": 1513.35,
+      "end": 1513.59,
+      "text": "great."
+    },
+    {
+      "start": 1513.59,
+      "end": 1513.83,
+      "text": "Yep."
+    },
+    {
+      "start": 1513.83,
+      "end": 1514.15,
+      "text": "Easy."
+    },
+    {
+      "start": 1514.36,
+      "end": 1515.24,
+      "text": "We're"
+    },
+    {
+      "start": 1515.24,
+      "end": 1515.48,
+      "text": "heading"
+    },
+    {
+      "start": 1515.48,
+      "end": 1515.88,
+      "text": "into"
+    },
+    {
+      "start": 1515.88,
+      "end": 1516.12,
+      "text": "the"
+    },
+    {
+      "start": 1516.12,
+      "end": 1516.44,
+      "text": "coffee"
+    },
+    {
+      "start": 1516.44,
+      "end": 1516.92,
+      "text": "break,"
+    },
+    {
+      "start": 1516.92,
+      "end": 1517.08,
+      "text": "we"
+    },
+    {
+      "start": 1517.08,
+      "end": 1517.16,
+      "text": "have"
+    },
+    {
+      "start": 1517.16,
+      "end": 1517.32,
+      "text": "a"
+    },
+    {
+      "start": 1517.32,
+      "end": 1517.48,
+      "text": "couple"
+    },
+    {
+      "start": 1517.48,
+      "end": 1517.56,
+      "text": "of"
+    },
+    {
+      "start": 1517.56,
+      "end": 1518.2,
+      "text": "minutes."
+    },
+    {
+      "start": 1519.16,
+      "end": 1519.56,
+      "text": "Questions?"
+    },
+    {
+      "start": 1527.78,
+      "end": 1528.1,
+      "text": "So"
+    },
+    {
+      "start": 1528.11,
+      "end": 1528.99,
+      "text": "users"
+    },
+    {
+      "start": 1529.07,
+      "end": 1529.55,
+      "text": "knowing"
+    },
+    {
+      "start": 1529.54,
+      "end": 1529.86,
+      "text": "that"
+    },
+    {
+      "start": 1529.87,
+      "end": 1530.11,
+      "text": "they're"
+    },
+    {
+      "start": 1530.11,
+      "end": 1530.59,
+      "text": "participating"
+    },
+    {
+      "start": 1530.59,
+      "end": 1530.75,
+      "text": "in"
+    },
+    {
+      "start": 1530.74,
+      "end": 1530.82,
+      "text": "the"
+    },
+    {
+      "start": 1530.83,
+      "end": 1531.55,
+      "text": "atmosphere,"
+    },
+    {
+      "start": 1531.54,
+      "end": 1531.7,
+      "text": "not"
+    },
+    {
+      "start": 1531.7,
+      "end": 1531.94,
+      "text": "just"
+    },
+    {
+      "start": 1531.94,
+      "end": 1532.26,
+      "text": "blue"
+    },
+    {
+      "start": 1532.27,
+      "end": 1532.83,
+      "text": "sky."
+    },
+    {
+      "start": 1533.22,
+      "end": 1533.54,
+      "text": "How"
+    },
+    {
+      "start": 1533.54,
+      "end": 1533.7,
+      "text": "do"
+    },
+    {
+      "start": 1533.7,
+      "end": 1533.78,
+      "text": "we"
+    },
+    {
+      "start": 1533.78,
+      "end": 1533.86,
+      "text": "do"
+    },
+    {
+      "start": 1533.87,
+      "end": 1534.03,
+      "text": "it?"
+    },
+    {
+      "start": 1534.02,
+      "end": 1534.18,
+      "text": "What's"
+    },
+    {
+      "start": 1534.18,
+      "end": 1534.34,
+      "text": "the"
+    },
+    {
+      "start": 1534.35,
+      "end": 1534.91,
+      "text": "branding?"
+    },
+    {
+      "start": 1534.98,
+      "end": 1535.46,
+      "text": "That's"
+    },
+    {
+      "start": 1535.46,
+      "end": 1535.62,
+      "text": "a"
+    },
+    {
+      "start": 1535.63,
+      "end": 1536.03,
+      "text": "great"
+    },
+    {
+      "start": 1536.02,
+      "end": 1536.58,
+      "text": "question,"
+    },
+    {
+      "start": 1536.59,
+      "end": 1536.75,
+      "text": "and"
+    },
+    {
+      "start": 1536.74,
+      "end": 1536.82,
+      "text": "we"
+    },
+    {
+      "start": 1536.83,
+      "end": 1537.07,
+      "text": "should"
+    },
+    {
+      "start": 1537.07,
+      "end": 1537.31,
+      "text": "figure"
+    },
+    {
+      "start": 1537.3,
+      "end": 1537.46,
+      "text": "that"
+    },
+    {
+      "start": 1537.46,
+      "end": 1537.94,
+      "text": "out."
+    },
+    {
+      "start": 1538.27,
+      "end": 1538.91,
+      "text": "This"
+    },
+    {
+      "start": 1538.74,
+      "end": 1539.3,
+      "text": "gentleman"
+    },
+    {
+      "start": 1539.3,
+      "end": 1539.78,
+      "text": "just"
+    },
+    {
+      "start": 1539.78,
+      "end": 1540.02,
+      "text": "showed"
+    },
+    {
+      "start": 1540.02,
+      "end": 1540.18,
+      "text": "you"
+    },
+    {
+      "start": 1540.18,
+      "end": 1540.34,
+      "text": "an"
+    },
+    {
+      "start": 1540.35,
+      "end": 1540.91,
+      "text": "ASCII"
+    },
+    {
+      "start": 1540.9,
+      "end": 1541.54,
+      "text": "presentation."
+    },
+    {
+      "start": 1543.82,
+      "end": 1544.22,
+      "text": "This"
+    },
+    {
+      "start": 1544.22,
+      "end": 1544.78,
+      "text": "presentation"
+    },
+    {
+      "start": 1544.78,
+      "end": 1545.1,
+      "text": "came"
+    },
+    {
+      "start": 1545.1,
+      "end": 1545.34,
+      "text": "from"
+    },
+    {
+      "start": 1545.34,
+      "end": 1545.5,
+      "text": "our"
+    },
+    {
+      "start": 1545.5,
+      "end": 1546.14,
+      "text": "designer."
+    },
+    {
+      "start": 1546.14,
+      "end": 1546.22,
+      "text": "I"
+    },
+    {
+      "start": 1546.22,
+      "end": 1546.38,
+      "text": "wanna"
+    },
+    {
+      "start": 1546.38,
+      "end": 1546.62,
+      "text": "call"
+    },
+    {
+      "start": 1546.62,
+      "end": 1546.78,
+      "text": "that"
+    },
+    {
+      "start": 1546.78,
+      "end": 1547.02,
+      "text": "a"
+    },
+    {
+      "start": 1549.1,
+      "end": 1549.5,
+      "text": "No."
+    },
+    {
+      "start": 1549.5,
+      "end": 1549.74,
+      "text": "That's"
+    },
+    {
+      "start": 1549.74,
+      "end": 1549.82,
+      "text": "a"
+    },
+    {
+      "start": 1549.82,
+      "end": 1550.7,
+      "text": "that's"
+    },
+    {
+      "start": 1550.7,
+      "end": 1550.86,
+      "text": "a"
+    },
+    {
+      "start": 1550.86,
+      "end": 1551.02,
+      "text": "good"
+    },
+    {
+      "start": 1551.02,
+      "end": 1551.34,
+      "text": "question."
+    },
+    {
+      "start": 1551.34,
+      "end": 1551.42,
+      "text": "I"
+    },
+    {
+      "start": 1551.42,
+      "end": 1551.58,
+      "text": "think"
+    },
+    {
+      "start": 1551.58,
+      "end": 1551.74,
+      "text": "that"
+    },
+    {
+      "start": 1551.74,
+      "end": 1551.9,
+      "text": "that"
+    },
+    {
+      "start": 1551.9,
+      "end": 1552.06,
+      "text": "is"
+    },
+    {
+      "start": 1552.14,
+      "end": 1552.22,
+      "text": "I"
+    },
+    {
+      "start": 1552.22,
+      "end": 1552.46,
+      "text": "mean,"
+    },
+    {
+      "start": 1552.46,
+      "end": 1552.54,
+      "text": "I"
+    },
+    {
+      "start": 1552.54,
+      "end": 1552.7,
+      "text": "don't"
+    },
+    {
+      "start": 1552.7,
+      "end": 1552.78,
+      "text": "have"
+    },
+    {
+      "start": 1552.78,
+      "end": 1552.94,
+      "text": "the"
+    },
+    {
+      "start": 1552.94,
+      "end": 1553.1,
+      "text": "answer"
+    },
+    {
+      "start": 1553.1,
+      "end": 1553.34,
+      "text": "for"
+    },
+    {
+      "start": 1553.34,
+      "end": 1553.42,
+      "text": "you"
+    },
+    {
+      "start": 1553.42,
+      "end": 1553.58,
+      "text": "right"
+    },
+    {
+      "start": 1553.58,
+      "end": 1553.82,
+      "text": "now,"
+    },
+    {
+      "start": 1553.82,
+      "end": 1553.9,
+      "text": "but"
+    },
+    {
+      "start": 1553.9,
+      "end": 1554.06,
+      "text": "that"
+    },
+    {
+      "start": 1554.06,
+      "end": 1554.46,
+      "text": "is"
+    },
+    {
+      "start": 1554.46,
+      "end": 1554.78,
+      "text": "the"
+    },
+    {
+      "start": 1554.78,
+      "end": 1555.1,
+      "text": "core"
+    },
+    {
+      "start": 1555.1,
+      "end": 1555.5,
+      "text": "question"
+    },
+    {
+      "start": 1555.5,
+      "end": 1555.74,
+      "text": "that"
+    },
+    {
+      "start": 1555.74,
+      "end": 1555.9,
+      "text": "we"
+    },
+    {
+      "start": 1555.9,
+      "end": 1556.06,
+      "text": "need"
+    },
+    {
+      "start": 1556.06,
+      "end": 1556.14,
+      "text": "to"
+    },
+    {
+      "start": 1556.14,
+      "end": 1556.38,
+      "text": "figure"
+    },
+    {
+      "start": 1556.38,
+      "end": 1556.54,
+      "text": "out"
+    },
+    {
+      "start": 1556.54,
+      "end": 1556.78,
+      "text": "this"
+    },
+    {
+      "start": 1556.78,
+      "end": 1557.1,
+      "text": "year"
+    },
+    {
+      "start": 1557.1,
+      "end": 1557.34,
+      "text": "is"
+    },
+    {
+      "start": 1557.34,
+      "end": 1557.82,
+      "text": "how"
+    },
+    {
+      "start": 1557.82,
+      "end": 1557.9,
+      "text": "do"
+    },
+    {
+      "start": 1557.9,
+      "end": 1558.06,
+      "text": "we"
+    },
+    {
+      "start": 1558.06,
+      "end": 1558.3,
+      "text": "start"
+    },
+    {
+      "start": 1558.3,
+      "end": 1558.46,
+      "text": "to"
+    },
+    {
+      "start": 1558.46,
+      "end": 1558.94,
+      "text": "build"
+    },
+    {
+      "start": 1559.04,
+      "end": 1559.68,
+      "text": "intuition"
+    },
+    {
+      "start": 1559.68,
+      "end": 1559.84,
+      "text": "for"
+    },
+    {
+      "start": 1559.85,
+      "end": 1560.17,
+      "text": "users"
+    },
+    {
+      "start": 1560.16,
+      "end": 1560.48,
+      "text": "about"
+    },
+    {
+      "start": 1560.48,
+      "end": 1560.72,
+      "text": "what"
+    },
+    {
+      "start": 1560.72,
+      "end": 1560.88,
+      "text": "the"
+    },
+    {
+      "start": 1560.88,
+      "end": 1561.2,
+      "text": "atmosphere"
+    },
+    {
+      "start": 1561.2,
+      "end": 1561.6,
+      "text": "is,"
+    },
+    {
+      "start": 1561.61,
+      "end": 1561.77,
+      "text": "what"
+    },
+    {
+      "start": 1561.77,
+      "end": 1562.01,
+      "text": "they're"
+    },
+    {
+      "start": 1562.01,
+      "end": 1562.49,
+      "text": "participating"
+    },
+    {
+      "start": 1562.48,
+      "end": 1562.88,
+      "text": "in,"
+    },
+    {
+      "start": 1562.88,
+      "end": 1563.04,
+      "text": "what"
+    },
+    {
+      "start": 1563.04,
+      "end": 1563.28,
+      "text": "an"
+    },
+    {
+      "start": 1563.28,
+      "end": 1563.6,
+      "text": "atmosphere"
+    },
+    {
+      "start": 1563.61,
+      "end": 1564.01,
+      "text": "account"
+    },
+    {
+      "start": 1564.01,
+      "end": 1564.41,
+      "text": "is,"
+    },
+    {
+      "start": 1564.4,
+      "end": 1564.56,
+      "text": "and"
+    },
+    {
+      "start": 1564.57,
+      "end": 1564.81,
+      "text": "what"
+    },
+    {
+      "start": 1564.8,
+      "end": 1564.96,
+      "text": "this"
+    },
+    {
+      "start": 1564.96,
+      "end": 1565.2,
+      "text": "whole"
+    },
+    {
+      "start": 1565.2,
+      "end": 1565.76,
+      "text": "OpenSocial"
+    },
+    {
+      "start": 1565.77,
+      "end": 1565.93,
+      "text": "thing"
+    },
+    {
+      "start": 1565.92,
+      "end": 1566.16,
+      "text": "is"
+    },
+    {
+      "start": 1566.16,
+      "end": 1566.64,
+      "text": "about."
+    },
+    {
+      "start": 1568.88,
+      "end": 1569.6,
+      "text": "How"
+    },
+    {
+      "start": 1569.61,
+      "end": 1569.93,
+      "text": "is"
+    },
+    {
+      "start": 1569.92,
+      "end": 1570.4,
+      "text": "the"
+    },
+    {
+      "start": 1570.4,
+      "end": 1570.8,
+      "text": "Swiss"
+    },
+    {
+      "start": 1570.8,
+      "end": 1571.36,
+      "text": "Association"
+    },
+    {
+      "start": 1571.37,
+      "end": 1572.01,
+      "text": "funded?"
+    },
+    {
+      "start": 1572.01,
+      "end": 1572.17,
+      "text": "Is"
+    },
+    {
+      "start": 1572.16,
+      "end": 1572.32,
+      "text": "that"
+    },
+    {
+      "start": 1572.33,
+      "end": 1572.49,
+      "text": "like"
+    },
+    {
+      "start": 1572.48,
+      "end": 1572.64,
+      "text": "a"
+    },
+    {
+      "start": 1572.64,
+      "end": 1572.88,
+      "text": "grant"
+    },
+    {
+      "start": 1572.88,
+      "end": 1573.12,
+      "text": "from"
+    },
+    {
+      "start": 1573.13,
+      "end": 1573.37,
+      "text": "Blue"
+    },
+    {
+      "start": 1573.37,
+      "end": 1573.85,
+      "text": "Sky?"
+    },
+    {
+      "start": 1573.85,
+      "end": 1574.17,
+      "text": "And"
+    },
+    {
+      "start": 1574.16,
+      "end": 1574.48,
+      "text": "how"
+    },
+    {
+      "start": 1574.48,
+      "end": 1574.8,
+      "text": "does"
+    },
+    {
+      "start": 1574.8,
+      "end": 1575.76,
+      "text": "this"
+    },
+    {
+      "start": 1574.94,
+      "end": 1575.26,
+      "text": "thing"
+    },
+    {
+      "start": 1575.26,
+      "end": 1576.06,
+      "text": "continue"
+    },
+    {
+      "start": 1576.06,
+      "end": 1576.46,
+      "text": "even"
+    },
+    {
+      "start": 1576.46,
+      "end": 1576.94,
+      "text": "if"
+    },
+    {
+      "start": 1576.94,
+      "end": 1577.26,
+      "text": "one"
+    },
+    {
+      "start": 1577.26,
+      "end": 1577.42,
+      "text": "of"
+    },
+    {
+      "start": 1577.42,
+      "end": 1577.58,
+      "text": "your"
+    },
+    {
+      "start": 1577.58,
+      "end": 1578.06,
+      "text": "scenarios"
+    },
+    {
+      "start": 1578.06,
+      "end": 1578.38,
+      "text": "Blue"
+    },
+    {
+      "start": 1578.38,
+      "end": 1578.62,
+      "text": "Sky"
+    },
+    {
+      "start": 1578.62,
+      "end": 1578.86,
+      "text": "went"
+    },
+    {
+      "start": 1578.86,
+      "end": 1579.1,
+      "text": "went"
+    },
+    {
+      "start": 1579.1,
+      "end": 1579.74,
+      "text": "away?"
+    },
+    {
+      "start": 1580.22,
+      "end": 1580.62,
+      "text": "That's"
+    },
+    {
+      "start": 1580.62,
+      "end": 1580.7,
+      "text": "a"
+    },
+    {
+      "start": 1580.7,
+      "end": 1580.86,
+      "text": "good"
+    },
+    {
+      "start": 1580.86,
+      "end": 1581.42,
+      "text": "question."
+    },
+    {
+      "start": 1581.66,
+      "end": 1582.06,
+      "text": "Right"
+    },
+    {
+      "start": 1582.06,
+      "end": 1582.3,
+      "text": "now,"
+    },
+    {
+      "start": 1582.3,
+      "end": 1582.38,
+      "text": "it"
+    },
+    {
+      "start": 1582.38,
+      "end": 1582.46,
+      "text": "is"
+    },
+    {
+      "start": 1582.46,
+      "end": 1582.78,
+      "text": "funded"
+    },
+    {
+      "start": 1582.78,
+      "end": 1583.02,
+      "text": "via"
+    },
+    {
+      "start": 1583.02,
+      "end": 1583.1,
+      "text": "a"
+    },
+    {
+      "start": 1583.1,
+      "end": 1583.34,
+      "text": "grant"
+    },
+    {
+      "start": 1583.34,
+      "end": 1583.5,
+      "text": "from"
+    },
+    {
+      "start": 1583.5,
+      "end": 1583.74,
+      "text": "Blue"
+    },
+    {
+      "start": 1583.74,
+      "end": 1584.3,
+      "text": "Sky."
+    },
+    {
+      "start": 1584.94,
+      "end": 1585.26,
+      "text": "The"
+    },
+    {
+      "start": 1585.26,
+      "end": 1585.58,
+      "text": "exact"
+    },
+    {
+      "start": 1585.58,
+      "end": 1585.98,
+      "text": "details"
+    },
+    {
+      "start": 1585.98,
+      "end": 1586.14,
+      "text": "of"
+    },
+    {
+      "start": 1586.14,
+      "end": 1586.3,
+      "text": "that"
+    },
+    {
+      "start": 1586.3,
+      "end": 1586.7,
+      "text": "haven't"
+    },
+    {
+      "start": 1586.7,
+      "end": 1586.94,
+      "text": "been"
+    },
+    {
+      "start": 1586.94,
+      "end": 1587.34,
+      "text": "nailed"
+    },
+    {
+      "start": 1587.34,
+      "end": 1587.5,
+      "text": "down"
+    },
+    {
+      "start": 1587.5,
+      "end": 1587.74,
+      "text": "just"
+    },
+    {
+      "start": 1587.74,
+      "end": 1587.98,
+      "text": "yet,"
+    },
+    {
+      "start": 1588.04,
+      "end": 1588.6,
+      "text": "Although,"
+    },
+    {
+      "start": 1588.6,
+      "end": 1588.76,
+      "text": "it"
+    },
+    {
+      "start": 1588.76,
+      "end": 1588.92,
+      "text": "will"
+    },
+    {
+      "start": 1588.91,
+      "end": 1589.23,
+      "text": "probably"
+    },
+    {
+      "start": 1589.23,
+      "end": 1589.63,
+      "text": "provide"
+    },
+    {
+      "start": 1589.63,
+      "end": 1589.87,
+      "text": "some"
+    },
+    {
+      "start": 1589.88,
+      "end": 1590.04,
+      "text": "sort"
+    },
+    {
+      "start": 1590.04,
+      "end": 1590.2,
+      "text": "of"
+    },
+    {
+      "start": 1590.2,
+      "end": 1590.76,
+      "text": "ongoing"
+    },
+    {
+      "start": 1590.76,
+      "end": 1591.4,
+      "text": "funding."
+    },
+    {
+      "start": 1591.47,
+      "end": 1591.63,
+      "text": "And"
+    },
+    {
+      "start": 1591.63,
+      "end": 1592.03,
+      "text": "then,"
+    },
+    {
+      "start": 1592.04,
+      "end": 1592.2,
+      "text": "the"
+    },
+    {
+      "start": 1592.2,
+      "end": 1592.92,
+      "text": "association"
+    },
+    {
+      "start": 1592.91,
+      "end": 1593.23,
+      "text": "is"
+    },
+    {
+      "start": 1593.23,
+      "end": 1593.47,
+      "text": "going"
+    },
+    {
+      "start": 1593.47,
+      "end": 1593.95,
+      "text": "to"
+    },
+    {
+      "start": 1593.96,
+      "end": 1594.76,
+      "text": "be"
+    },
+    {
+      "start": 1595.15,
+      "end": 1595.55,
+      "text": "working"
+    },
+    {
+      "start": 1595.56,
+      "end": 1595.8,
+      "text": "to"
+    },
+    {
+      "start": 1595.8,
+      "end": 1596.44,
+      "text": "provide,"
+    },
+    {
+      "start": 1596.52,
+      "end": 1596.68,
+      "text": "you"
+    },
+    {
+      "start": 1596.67,
+      "end": 1597.15,
+      "text": "know,"
+    },
+    {
+      "start": 1597.15,
+      "end": 1597.39,
+      "text": "more"
+    },
+    {
+      "start": 1597.39,
+      "end": 1597.87,
+      "text": "sustainable"
+    },
+    {
+      "start": 1597.88,
+      "end": 1598.28,
+      "text": "funding"
+    },
+    {
+      "start": 1598.28,
+      "end": 1598.6,
+      "text": "options"
+    },
+    {
+      "start": 1598.6,
+      "end": 1599,
+      "text": "after"
+    },
+    {
+      "start": 1598.99,
+      "end": 1599.39,
+      "text": "that."
+    },
+    {
+      "start": 1599.39,
+      "end": 1599.55,
+      "text": "But"
+    },
+    {
+      "start": 1599.56,
+      "end": 1600.2,
+      "text": "ultimately,"
+    },
+    {
+      "start": 1600.2,
+      "end": 1600.36,
+      "text": "that's"
+    },
+    {
+      "start": 1600.36,
+      "end": 1600.52,
+      "text": "going"
+    },
+    {
+      "start": 1600.52,
+      "end": 1600.6,
+      "text": "to"
+    },
+    {
+      "start": 1600.6,
+      "end": 1600.68,
+      "text": "be"
+    },
+    {
+      "start": 1600.67,
+      "end": 1600.75,
+      "text": "the"
+    },
+    {
+      "start": 1600.76,
+      "end": 1601.16,
+      "text": "prerogative"
+    },
+    {
+      "start": 1601.15,
+      "end": 1601.31,
+      "text": "of"
+    },
+    {
+      "start": 1601.32,
+      "end": 1601.4,
+      "text": "the"
+    },
+    {
+      "start": 1601.39,
+      "end": 1601.63,
+      "text": "Swiss"
+    },
+    {
+      "start": 1601.63,
+      "end": 1602.35,
+      "text": "Association,"
+    },
+    {
+      "start": 1602.36,
+      "end": 1602.44,
+      "text": "not"
+    },
+    {
+      "start": 1602.43,
+      "end": 1602.67,
+      "text": "Blue"
+    },
+    {
+      "start": 1602.67,
+      "end": 1602.91,
+      "text": "Sky."
+    },
+    {
+      "start": 1606.47,
+      "end": 1607.43,
+      "text": "Let's"
+    },
+    {
+      "start": 1607.43,
+      "end": 1607.59,
+      "text": "go"
+    },
+    {
+      "start": 1607.59,
+      "end": 1607.75,
+      "text": "get"
+    },
+    {
+      "start": 1607.75,
+      "end": 1607.99,
+      "text": "some"
+    },
+    {
+      "start": 1607.99,
+      "end": 1608.47,
+      "text": "coffee."
+    },
+    {
+      "start": 1608.47,
+      "end": 1608.87,
+      "text": "Thanks,"
+    },
+    {
+      "start": 1608.87,
+      "end": 1609.19,
+      "text": "Dan."
+    },
+    {
+      "start": 1609.19,
+      "end": 1609.43,
+      "text": "Nice."
+    }
+  ],
+  "paragraphs": [
+    {
+      "start": 1.44,
+      "end": 2.64
+    },
+    {
+      "start": 6.88,
+      "end": 36.84
+    },
+    {
+      "start": 36.92,
+      "end": 70.68
+    },
+    {
+      "start": 74.11,
+      "end": 112.09
+    },
+    {
+      "start": 114.01,
+      "end": 144.74
+    },
+    {
+      "start": 144.74,
+      "end": 181.54
+    },
+    {
+      "start": 181.75,
+      "end": 220.95
+    },
+    {
+      "start": 221.11,
+      "end": 255.54
+    },
+    {
+      "start": 255.54,
+      "end": 291.41
+    },
+    {
+      "start": 292.04,
+      "end": 331.63
+    },
+    {
+      "start": 331.63,
+      "end": 369.5
+    },
+    {
+      "start": 369.5,
+      "end": 408.96
+    },
+    {
+      "start": 409.12,
+      "end": 440.77
+    },
+    {
+      "start": 440.77,
+      "end": 477.33
+    },
+    {
+      "start": 477.41,
+      "end": 517.69
+    },
+    {
+      "start": 519.13,
+      "end": 554.74
+    },
+    {
+      "start": 555.12,
+      "end": 590.98
+    },
+    {
+      "start": 592.02,
+      "end": 615.66
+    },
+    {
+      "start": 622.62,
+      "end": 650.09
+    },
+    {
+      "start": 650.09,
+      "end": 687.63
+    },
+    {
+      "start": 688.43,
+      "end": 726.5
+    },
+    {
+      "start": 729.14,
+      "end": 762.04
+    },
+    {
+      "start": 762.12,
+      "end": 799.33
+    },
+    {
+      "start": 799.34,
+      "end": 832.73
+    },
+    {
+      "start": 833.13,
+      "end": 871.06
+    },
+    {
+      "start": 871.46,
+      "end": 901.08
+    },
+    {
+      "start": 901.16,
+      "end": 935.29
+    },
+    {
+      "start": 935.71,
+      "end": 970.47
+    },
+    {
+      "start": 972.24,
+      "end": 1004.47
+    },
+    {
+      "start": 1004.54,
+      "end": 1046.44
+    },
+    {
+      "start": 1047.26,
+      "end": 1081.42
+    },
+    {
+      "start": 1081.49,
+      "end": 1118.06
+    },
+    {
+      "start": 1120.16,
+      "end": 1157.23
+    },
+    {
+      "start": 1163.71,
+      "end": 1195.62
+    },
+    {
+      "start": 1201.93,
+      "end": 1237.36
+    },
+    {
+      "start": 1238.16,
+      "end": 1272.81
+    },
+    {
+      "start": 1273.58,
+      "end": 1305.35
+    },
+    {
+      "start": 1306.8,
+      "end": 1347.34
+    },
+    {
+      "start": 1349.1,
+      "end": 1385.19
+    },
+    {
+      "start": 1385.19,
+      "end": 1415.76
+    },
+    {
+      "start": 1416.53,
+      "end": 1453.12
+    },
+    {
+      "start": 1453.13,
+      "end": 1486.34
+    },
+    {
+      "start": 1487.26,
+      "end": 1497.82
+    },
+    {
+      "start": 1506.07,
+      "end": 1513.83,
+      "speaker": "speaker-1"
+    },
+    {
+      "start": 1513.83,
+      "end": 1514.15,
+      "speaker": "speaker-0"
+    },
+    {
+      "start": 1514.36,
+      "end": 1519.56,
+      "speaker": "speaker-1"
+    },
+    {
+      "start": 1527.78,
+      "end": 1534.91,
+      "speaker": "speaker-2"
+    },
+    {
+      "start": 1534.98,
+      "end": 1537.94,
+      "speaker": "speaker-0"
+    },
+    {
+      "start": 1538.27,
+      "end": 1541.54,
+      "speaker": "speaker-1"
+    },
+    {
+      "start": 1543.82,
+      "end": 1566.64,
+      "speaker": "speaker-0"
+    },
+    {
+      "start": 1568.88,
+      "end": 1579.74,
+      "speaker": "speaker-3"
+    },
+    {
+      "start": 1580.22,
+      "end": 1602.91,
+      "speaker": "speaker-0"
+    },
+    {
+      "start": 1606.47,
+      "end": 1609.43,
+      "speaker": "speaker-1"
+    }
+  ]
+}

--- a/src/lib/caption.js
+++ b/src/lib/caption.js
@@ -1,0 +1,370 @@
+/*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
+/*! Version 2.1.4 */
+// Vendored from https://github.com/hyperaudio/hyperaudio-lite/blob/v2.4.2/js/caption.js
+// Same one-line ESM export shim as hyperaudio-lite.js; remove the vendored
+// copy when upstream ships an importable build.
+'use strict';
+
+var caption = function () {
+  var cap = {};
+
+  function formatSeconds(seconds) {
+    if (typeof seconds == 'number') {
+      //console.log("seconds = "+seconds);
+      return new Date(seconds.toFixed(3) * 1000).toISOString().substring(11,23);
+    } else {
+      console.log('warning - attempting to format the non number: ' + seconds);
+      return null;
+    }
+  }
+
+  function convertTimecodeToSrt(timecode) {
+    //the same as VTT format but milliseconds separated by a comma
+    return timecode.substring(0,8) + "," + timecode.substring(9,12);
+  }
+
+  cap.init = function (transcriptId, playerId, maxLength, minLength, label, srclang) {
+    var transcript = document.getElementById(transcriptId);
+    var words = transcript.querySelectorAll('[data-m]');
+    var data = {};
+    data.segments = [];
+
+    function segmentMeta(speaker, start, duration, chars) {
+      this.speaker = speaker;
+      this.start = start;
+      this.duration = duration;
+      this.chars = chars;
+      this.words = [];
+    }
+
+    function wordMeta(start, duration, text) {
+      this.start = start;
+      this.duration = duration;
+      this.text = text;
+    }
+
+    var thisWordMeta;
+    var thisSegmentMeta = null;
+
+    // defaults
+    var maxLineLength = 37;
+    var minLineLength = 21;
+    var maxWordDuration = 2; //seconds
+
+    var captionsVtt = 'WEBVTT\n';
+    var captionsSrt = '';
+
+    var endSentenceDelimiter = /[\.。?؟!]/g;
+    var midSentenceDelimiter = /[,、–，،و:，…‥]/g;
+
+    if (!isNaN(maxLength) && maxLength != null) {
+      maxLineLength = maxLength;
+    }
+
+    if (!isNaN(minLength) && minLength != null) {
+      minLineLength = minLength;
+    }
+
+    words.forEach(function (word, i) {
+      if (thisSegmentMeta === null) {
+        // create segment meta object
+        thisSegmentMeta = new segmentMeta('', null, 0, 0, 0);
+      }
+
+      if (word.classList.contains('speaker')) {
+        // checking that this is not a new segment AND a new empty segment wasn't already created
+        if (thisSegmentMeta !== null && thisSegmentMeta.start !== null) {
+          data.segments.push(thisSegmentMeta); // push the previous segment because it's a new speaker
+          thisSegmentMeta = new segmentMeta('', null, 0, 0, 0);
+        }
+
+        thisSegmentMeta.speaker = word.innerText;
+      } else {
+        var thisStart = parseInt(word.getAttribute('data-m')) / 1000;
+        var thisDuration = parseInt(word.getAttribute('data-d')) / 1000;
+
+        if (isNaN(thisStart)) {
+          thisStart = 0;
+        }
+
+        // data-d (duration) is an optional attribute, if it doesn't exist 
+        // use the start time of the next word (if it exists) or for the last word
+        // pick a sensible duration.  
+
+        if (isNaN(thisDuration)) {
+          if (i < (words.length - 1)) {
+            thisDuration = (parseInt(words[i+1].getAttribute('data-m') - 1) / 1000) - thisStart;
+            if (thisDuration > maxWordDuration) {
+              thisDuration = maxWordDuration;
+            }
+          } else {
+            thisDuration = 5; // sensible default for the last word
+          }
+        }
+
+        var thisText = word.innerText;
+
+        thisWordMeta = new wordMeta(thisStart, thisDuration, thisText);
+
+        if (thisSegmentMeta.start === null) {
+          thisSegmentMeta.start = thisStart;
+          thisSegmentMeta.duration = 0;
+          thisSegmentMeta.chars = 0;
+        }
+
+        thisSegmentMeta.duration += thisDuration;
+        thisSegmentMeta.chars += thisText.length;
+
+        thisSegmentMeta.words.push(thisWordMeta);
+
+        // remove spaces first just in case
+        var lastChar = thisText.replace(/\s/g, '').slice(-1);
+        if (lastChar.match(endSentenceDelimiter)) {
+          data.segments.push(thisSegmentMeta);
+          thisSegmentMeta = null;
+        }
+      }
+    });
+
+    //console.log(data);
+
+    data.segments.map(function (segment, i, arr) {
+      var sentence = "";
+      segment.words.forEach(function (wordMeta) {
+        sentence += wordMeta.text;
+      });
+      //console.log(msToTime(segment.start*1000) + " " + sentence);
+    });
+
+    function msToTime(duration) {
+      var milliseconds = Math.floor((duration % 1000) / 100),
+        seconds = Math.floor((duration / 1000) % 60),
+        minutes = Math.floor((duration / (1000 * 60)) % 60),
+        hours = Math.floor((duration / (1000 * 60 * 60)) % 24);
+    
+      hours = (hours < 10) ? "0" + hours : hours;
+      minutes = (minutes < 10) ? "0" + minutes : minutes;
+      seconds = (seconds < 10) ? "0" + seconds : seconds;
+    
+      return hours + ":" + minutes + ":" + seconds;
+    }
+
+    function captionMeta(start, stop, text) {
+      this.start = start;
+      this.stop = stop;
+      this.text = text;
+    }
+
+    var captions = [];
+    var thisCaption = null;
+
+    data.segments.map(function (segment, i, arr) {
+      // If the entire segment fits on a line, add it to the captions.
+      if (segment.chars < maxLineLength) {
+
+        if (segment.duration === 0){
+          if (i < arr.length) {
+            segment.duration = arr[i+1].start - segment.start; 
+          } else {
+            segment.duration = 5 * 1000;
+          }
+        } 
+
+        thisCaption = new captionMeta(
+          formatSeconds(segment.start),
+          formatSeconds(segment.start + segment.duration),
+          '',
+        );
+
+        segment.words.forEach(function (wordMeta) {
+          thisCaption.text += wordMeta.text;
+        });
+
+        thisCaption.text += '\n';
+        //console.log("0. pushing because the whole segment fits on a line!");
+        //console.log(thisCaption);
+        captions.push(thisCaption);
+        thisCaption = null;
+      } else {
+        // The number of chars in this segment is longer than our single line maximum
+
+        var charCount = 0;
+        var lineText = '';
+        var firstLine = true;
+        var lastOutTime;
+        var lastInTime = null;
+
+        segment.words.forEach(function (wordMeta, index) {
+          var lastChar = wordMeta.text.replace(/\s/g, '').slice(-1);
+
+          if (lastInTime === null) {
+            // if it doesn't exist yet set the caption start time to the word's start time.
+            lastInTime = wordMeta.start;
+          }
+
+          // Are we over the minimum length of a line and hitting a good place to split mid-sentence?
+          if (charCount + wordMeta.text.length > minLineLength && lastChar.match(midSentenceDelimiter)) {
+            if (firstLine === true) {
+              thisCaption = new captionMeta(
+                formatSeconds(lastInTime),
+                formatSeconds(wordMeta.start + wordMeta.duration),
+                '',
+              );
+              thisCaption.text += lineText + wordMeta.text + '\n';
+
+              //check for last word in segment, if it is we can push a one line caption, if not – move on to second line
+
+              if (index + 1 >= segment.words.length) {
+                //console.log("1. pushing because we're at a good place to split, we're on the first line but it's the last word of the segment.");
+                //console.log(thisCaption);
+                captions.push(thisCaption);
+                thisCaption = null;
+              } else {
+                firstLine = false;
+              }
+            } else {
+              // We're on the second line ... we're over the minimum chars and in a good place to split – let's push the caption
+
+              thisCaption.stop = formatSeconds(wordMeta.start + wordMeta.duration);
+              thisCaption.text += lineText + wordMeta.text;
+              //console.log("2. pushing because we're on the second line and have a good place to split");
+              //console.log(thisCaption);
+              captions.push(thisCaption);
+              thisCaption = null;
+              firstLine = true;
+            }
+
+            // whether first line or not we should reset ready for a new caption
+            charCount = 0;
+            lineText = '';
+            lastInTime = null;
+          } else {
+            // we're not over the minimum length with a suitable splitting point
+
+            // If we add this word are we over the maximum?
+            if (charCount + wordMeta.text.length > maxLineLength) {
+              if (firstLine === true) {
+                if (lastOutTime === undefined) {
+                  lastOutTime = wordMeta.start + wordMeta.duration;
+                }
+
+                thisCaption = new captionMeta(formatSeconds(lastInTime), formatSeconds(lastOutTime), '');
+                thisCaption.text += lineText + '\n';
+
+                // It's just the first line so we should only push a new caption if it's the very last word!
+
+                if (index >= segment.words.length) {
+                  captions.push(thisCaption);
+                  thisCaption = null;
+                } else {
+                  firstLine = false;
+                }
+              } else {
+                // We're on the second line and since we're over the maximum with the next word we should push this caption!
+
+                thisCaption.stop = formatSeconds(lastOutTime);
+                thisCaption.text += lineText;
+
+                captions.push(thisCaption);
+
+                thisCaption = null;
+                firstLine = true;
+              }
+
+              // do the stuff we need to do to start a new line
+              charCount = wordMeta.text.length;
+              lineText = wordMeta.text;
+              lastInTime = wordMeta.start; 
+            } else {
+              // We're not over the maximum with this word, update the line length and add the word to the text
+
+              charCount += wordMeta.text.length;
+              lineText += wordMeta.text;
+            }
+          }
+
+          // for every word update the lastOutTime
+          lastOutTime = wordMeta.start + wordMeta.duration;
+        });
+
+        // we're out of words for this segment - decision time!
+        if (thisCaption !== null) {
+          // The caption had been started, time to add whatever text we have and add a stop point
+          thisCaption.stop = formatSeconds(lastOutTime);
+          thisCaption.text += lineText;
+          //console.log("3. pushing at end of segment when new caption HAS BEEN created");
+          //console.log(thisCaption);
+          captions.push(thisCaption);
+          thisCaption = null;
+        } else {
+          // caption hadn't been started yet - create one!
+          if (lastInTime !== null) {
+            thisCaption = new captionMeta(formatSeconds(lastInTime), formatSeconds(lastOutTime), lineText);
+            //console.log("4. pushing at end of segment when new caption has yet to be created");
+            //console.log(thisCaption);
+            captions.push(thisCaption);
+            thisCaption = null;
+          }
+        }
+      }
+    });
+
+    captions.forEach(function (caption, i) {
+      captionsVtt += '\n' + caption.start + ' --> ' + caption.stop + '\n' + caption.text + '\n';
+      //console.log(caption.start + ' --> ' + caption.stop + '\n' + caption.text);
+      captionsSrt += '\n' + (i + 1) + '\n' + convertTimecodeToSrt(caption.start) + ' --> ' + convertTimecodeToSrt(caption.stop) + '\n' + caption.text + '\n';
+    });
+
+    var video = document.getElementById(playerId);
+
+    if (video !== null) {
+      video.addEventListener("loadedmetadata", function listener() {
+
+        var track = document.getElementById(playerId+'-vtt');
+
+        if (track !== null){
+          track.kind = "captions";
+
+          if (label !== undefined) {
+            //console.log("setting label as "+label);
+            track.label = label;
+          }
+  
+          if (srclang !== undefined) {
+            //console.log("setting srclang as "+srclang);
+            track.srclang = srclang;
+          }
+
+          track.src = "data:text/vtt,"+encodeURIComponent(captionsVtt);
+          video.textTracks[0].mode = "showing";
+          video.removeEventListener("loadedmetadata", listener, true);
+        }
+        
+      }, true);
+  
+      if (video.textTracks !== undefined && video.textTracks[0] !== undefined) {
+        video.textTracks[0].mode = "showing";
+      }
+    }
+
+    function captionsObj(vtt, srt, data) {
+      // clean up – remove any double blank lines 
+      // and blank line at the start of srt
+
+      if (srt.charAt(0) !== "1") {
+        srt = srt.slice(1);
+      }
+
+      this.vtt = vtt.replaceAll("\n\n\n","\n\n");
+      this.srt = srt.replaceAll("\n\n\n","\n\n");
+      this.data = captions;
+    }
+
+    return new captionsObj(captionsVtt, captionsSrt, captions);
+  };
+
+  return cap;
+};
+
+// TEMPORARY local addition — see header for context.
+export { caption };

--- a/src/lib/hyperaudio-lite.js
+++ b/src/lib/hyperaudio-lite.js
@@ -1,0 +1,788 @@
+/*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
+/*! Version 2.4.0 */
+
+'use strict';
+
+// Base player class to handle common player functionality
+class BasePlayer {
+  constructor(instance) {
+    this.player = this.initPlayer(instance); // Initialize the player
+    this.paused = true; // Set initial paused state
+    if (this.player) {
+      this.attachEventListeners(instance); // Attach event listeners for play and pause
+    }
+  }
+
+  // Method to initialize the player - to be implemented by subclasses
+  initPlayer(instance) {
+    throw new Error('initPlayer method should be implemented by subclasses');
+  }
+
+  // Method to attach common event listeners
+  attachEventListeners(instance) {
+    this.player.addEventListener('pause', instance.pausePlayHead.bind(instance), false);
+    this.player.addEventListener('play', instance.preparePlayHead.bind(instance), false);
+  }
+
+  // Method to get the current time of the player
+  getTime() {
+    return Promise.resolve(this.player.currentTime);
+  }
+
+  // Method to set the current time of the player
+  setTime(seconds) {
+    this.player.currentTime = seconds;
+  }
+
+  // Method to play the media
+  play() {
+    this.player.play();
+    this.paused = false;
+  }
+
+  // Method to pause the media
+  pause() {
+    this.player.pause();
+    this.paused = true;
+  }
+}
+
+// Class for native HTML5 player
+class NativePlayer extends BasePlayer {
+  // Initialize the native HTML5 player
+  initPlayer(instance) {
+    return instance.player;
+  }
+}
+
+// Class for SoundCloud player
+class SoundCloudPlayer extends BasePlayer {
+  // Initialize the SoundCloud player
+  initPlayer(instance) {
+    return SC.Widget(instance.player.id);
+  }
+
+  // Attach event listeners specific to SoundCloud player
+  attachEventListeners(instance) {
+    this.player.bind(SC.Widget.Events.PAUSE, instance.pausePlayHead.bind(instance));
+    this.player.bind(SC.Widget.Events.PLAY, instance.preparePlayHead.bind(instance));
+  }
+
+  // Get the current time of the SoundCloud player
+  getTime() {
+    return new Promise(resolve => {
+      this.player.getPosition(ms => resolve(ms / 1000));
+    });
+  }
+
+  // Set the current time of the SoundCloud player
+  setTime(seconds) {
+    this.player.seekTo(seconds * 1000);
+  }
+}
+
+// Class for VideoJS player
+class VideoJSPlayer extends BasePlayer {
+  // Initialize the VideoJS player
+  initPlayer(instance) {
+    return videojs.getPlayer(instance.player.id);
+  }
+
+  // Get the current time of the VideoJS player
+  getTime() {
+    return Promise.resolve(this.player.currentTime());
+  }
+
+  // Set the current time of the VideoJS player
+  setTime(seconds) {
+    this.player.currentTime(seconds);
+  }
+}
+
+// Class for Vimeo player
+class VimeoPlayer extends BasePlayer {
+  // Initialize the Vimeo player
+  initPlayer(instance) {
+    const iframe = document.querySelector('iframe');
+    return new Vimeo.Player(iframe);
+  }
+
+  // Attach event listeners specific to Vimeo player
+  attachEventListeners(instance) {
+    this.player.ready().then(instance.checkPlayHead.bind(instance));
+    this.player.on('play', instance.preparePlayHead.bind(instance));
+    this.player.on('pause', instance.pausePlayHead.bind(instance));
+  }
+
+  // Get the current time of the Vimeo player
+  getTime() {
+    return this.player.getCurrentTime();
+  }
+
+  // Set the current time of the Vimeo player
+  setTime(seconds) {
+    this.player.setCurrentTime(seconds);
+  }
+}
+
+// Class for YouTube player
+class YouTubePlayer extends BasePlayer {
+  // Initialize the YouTube player by loading YouTube IFrame API
+  initPlayer(instance) {
+    // Defer attaching event listeners until the player is ready
+    this.isReady = false;
+
+    // Load the YouTube IFrame API script
+    if (!document.getElementById('iframe-demo')) {
+      const tag = document.createElement('script');
+      tag.id = 'iframe-demo';
+      tag.src = 'https://www.youtube.com/iframe_api';
+      const firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+    }
+
+    // Set the global callback for the YouTube IFrame API
+    window.onYouTubeIframeAPIReady = this.onYouTubeIframeAPIReady.bind(this, instance);
+  }
+
+  // Callback when YouTube IFrame API is ready
+  onYouTubeIframeAPIReady(instance) {
+    this.player = new YT.Player(instance.player.id, {
+      events: {
+        onStateChange: this.onPlayerStateChange.bind(this, instance),
+        onReady: this.onPlayerReady.bind(this)
+      }
+    });
+  }
+
+  // Event handler when the YouTube player is ready
+  onPlayerReady() {
+    this.isReady = true;
+  }
+
+  // Handle YouTube player state changes (play, pause)
+  onPlayerStateChange(instance, event) {
+    if (event.data === YT.PlayerState.PLAYING) { // Playing
+      instance.preparePlayHead();
+      this.paused = false;
+    } else if (event.data === YT.PlayerState.PAUSED) { // Paused
+      instance.pausePlayHead();
+      this.paused = true;
+    }
+  }
+
+  // Get the current time of the YouTube player
+  getTime() {
+    if (this.isReady) {
+      return Promise.resolve(this.player.getCurrentTime());
+    } else {
+      return Promise.resolve(0); // Return 0 if the player is not ready
+    }
+  }
+
+  // Set the current time of the YouTube player
+  setTime(seconds) {
+    if (this.isReady) {
+      this.player.seekTo(seconds, true);
+    }
+  }
+
+  // Play the YouTube video
+  play() {
+    if (this.isReady) {
+      this.player.playVideo();
+    }
+  }
+
+  // Pause the YouTube video
+  pause() {
+    if (this.isReady) {
+      this.player.pauseVideo();
+    }
+  }
+}
+
+// Class for Spotify player
+class SpotifyPlayer extends BasePlayer {
+  // Initialize the Spotify player by setting up the Spotify IFrame API
+  initPlayer(instance) {
+    window.onSpotifyIframeApiReady = IFrameAPI => {
+      const element = document.getElementById(instance.player.id);
+      const srcValue = element.getAttribute('src');
+      const episodeID = this.extractEpisodeID(srcValue);
+
+      const options = { uri: `spotify:episode:${episodeID}` };
+      const callback = player => {
+        this.player = player;
+        player.addListener('playback_update', e => {
+          if (e.data.isPaused !== true) {
+            this.currentTime = e.data.position / 1000;
+            instance.preparePlayHead();
+            this.paused = false;
+          } else {
+            instance.pausePlayHead();
+            this.paused = true;
+          }
+        });
+
+        player.addListener('ready', () => {
+          player.togglePlay(); // Priming the playhead
+          instance.checkPlayHead();
+        });
+      };
+
+      IFrameAPI.createController(element, options, callback);
+    };
+  }
+
+  // Extract episode ID from the Spotify URL
+  extractEpisodeID(url) {
+    const match = url.match(/episode\/(.+)$/);
+    return match ? match[1] : null;
+  }
+
+  // Get the current time of the Spotify player
+  getTime() {
+    return Promise.resolve(this.currentTime);
+  }
+
+  // Set the current time of the Spotify player
+  setTime(seconds) {
+    this.player.seek(seconds);
+  }
+
+  // Play the Spotify track
+  play() {
+    this.player.play();
+    this.paused = false;
+  }
+
+  // Pause the Spotify track
+  pause() {
+    this.player.togglePlay();
+    this.paused = true;
+  }
+}
+
+// Mapping player types to their respective classes
+const hyperaudioPlayerOptions = {
+  "native": NativePlayer,
+  "soundcloud": SoundCloudPlayer,
+  "youtube": YouTubePlayer,
+  "videojs": VideoJSPlayer,
+  "vimeo": VimeoPlayer,
+  "spotify": SpotifyPlayer
+};
+
+// Factory function to create player instances
+function hyperaudioPlayer(playerType, instance) {
+  if (playerType) {
+    return new hyperaudioPlayerOptions[playerType](instance);
+  } else {
+    console.warn("HYPERAUDIO LITE WARNING: data-player-type attribute should be set on player if not native, e.g., SoundCloud, YouTube, Vimeo, VideoJS");
+  }
+}
+
+// Main class for HyperaudioLite functionality
+class HyperaudioLite {
+  constructor(transcriptId, mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick) {
+    this.transcript = document.getElementById(transcriptId);
+    this.init(mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick);
+
+    // Ensure correct binding for class methods
+    this.preparePlayHead = this.preparePlayHead.bind(this);
+    this.pausePlayHead = this.pausePlayHead.bind(this);
+    this.setPlayHead = this.setPlayHead.bind(this);
+    this.checkPlayHead = this.checkPlayHead.bind(this);
+    this.clearTimer = this.clearTimer.bind(this);
+  }
+
+  // Initialize the HyperaudioLite instance
+  init(mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick) {
+    this.setupTranscriptHash();
+    this.setupPopover();
+    this.setupPlayer(mediaElementId);
+    this.setupTranscriptWords();
+    this.setupEventListeners(doubleClick, playOnClick);
+    this.setupInitialPlayHead();
+    this.setupAutoScroll(autoscroll);
+    this.minimizedMode = minimizedMode;
+    this.autoscroll = autoscroll;
+    this.webMonetization = webMonetization;
+  }
+
+  // Setup hash for transcript selection
+  setupTranscriptHash() {
+    const windowHash = window.location.hash;
+    const hashVar = windowHash.substring(1, windowHash.indexOf('='));
+
+    if (hashVar === this.transcript.id) {
+      this.hashArray = windowHash.substring(this.transcript.id.length + 2).split(',');
+    } else {
+      this.hashArray = [];
+    }
+  }
+
+  // Setup the popover for text selection
+  setupPopover() {
+    if (typeof popover !== 'undefined') {
+      this.transcript.addEventListener('mouseup', () => {
+        const selection = window.getSelection();
+        const popover = document.getElementById('popover');
+        let selectionText;
+  
+        if (selection.toString().length > 0) {
+          selectionText = selection.toString().replaceAll("'", "`");
+          const range = selection.getRangeAt(0);
+          const rect = range.getBoundingClientRect();
+  
+          popover.style.left = `${rect.left + window.scrollX}px`;
+          popover.style.top = `${rect.bottom + window.scrollY}px`;
+          popover.style.display = 'block';
+  
+          const mediaFragment = this.getSelectionMediaFragment();
+  
+          if (mediaFragment) {
+            document.location.hash = mediaFragment;
+          }
+        } else {
+          popover.style.display = 'none';
+        }
+  
+        const popoverBtn = document.getElementById('popover-btn');
+        popoverBtn.addEventListener('click', (e) => {
+          popover.style.display = 'none';
+          let cbText = `${selectionText} ${document.location}`;
+          navigator.clipboard.writeText(cbText);
+  
+          const dialog = document.getElementById("clipboard-dialog");
+          document.getElementById("clipboard-text").innerHTML = cbText;
+          dialog.showModal();
+  
+          const confirmButton = document.getElementById("clipboard-confirm");
+          confirmButton.addEventListener("click", () => dialog.close());
+  
+          e.preventDefault();
+          return false;
+        });
+      });
+    }
+  }
+
+  // Setup the media player
+  setupPlayer(mediaElementId) {
+    this.player = document.getElementById(mediaElementId);
+    const mediaSrc = this.transcript.querySelector('[data-media-src]');
+    if (mediaSrc) {
+      this.player.src = mediaSrc.getAttribute('data-media-src');
+    }
+
+    if (this.player.tagName === 'VIDEO' || this.player.tagName === 'AUDIO') {
+      this.playerType = 'native';
+    } else {
+      this.playerType = this.player.getAttribute('data-player-type');
+    }
+
+    this.myPlayer = hyperaudioPlayer(this.playerType, this);
+  }
+
+  // Setup the transcript words
+  setupTranscriptWords() {
+    const words = this.transcript.querySelectorAll('[data-m]');
+    this.wordArr = this.createWordArray(words);
+
+    // check for elements with data-m attributes that are not directly below <section>
+    // these will contain <p> or similar that we can scroll to
+
+    for (const word of words) {
+      let parentTagName = word.parentElement.tagName;
+      if (parentTagName !== "SECTION") {
+        this.parentTag = parentTagName;
+        break;
+      }
+    }
+
+    this.parentElements = this.transcript.getElementsByTagName(this.parentTag);
+  }
+
+  setupAutoScroll(autoscroll) {
+    this.autoscroll = autoscroll;
+    this.scrollContainer = this.transcript;
+  }
+
+  // Setup event listeners for interactions
+  setupEventListeners(doubleClick, playOnClick) {
+    this.minimizedMode = false;
+    this.autoscroll = false;
+    this.doubleClick = doubleClick;
+    this.webMonetization = false;
+    this.playOnClick = playOnClick;
+    this.highlightedText = false;
+    this.start = null;
+
+    const playHeadEvent = doubleClick ? 'dblclick' : 'click';
+    this.transcript.addEventListener(playHeadEvent, this.setPlayHead.bind(this), false);
+    this.transcript.addEventListener(playHeadEvent, this.checkPlayHead.bind(this), false);
+  }
+
+  // Setup initial playhead position based on URL hash
+  setupInitialPlayHead() {
+    this.start = this.hashArray[0];
+    if (!isNaN(parseFloat(this.start))) {
+      this.highlightedText = true;
+      let indices = this.updateTranscriptVisualState(this.start);
+      if (indices.currentWordIndex > 0 && this.autoscroll) {
+        this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
+      }
+    }
+
+    this.end = this.hashArray[1];
+    //TODO convert to binary search for below for quicker startup
+    if (this.start && this.end) {
+      const words = this.transcript.querySelectorAll('[data-m]');
+      for (let i = 1; i < words.length; i++) {
+        let startTime = parseInt(words[i].getAttribute('data-m')) / 1000;
+        let wordStart = (Math.round(startTime * 100) / 100).toFixed(2);
+        if (wordStart >= parseFloat(this.start) && parseFloat(this.end) > wordStart) {
+          words[i].classList.add('share-match');
+        }
+      }
+    }
+  }
+
+  // Create an array of words with metadata from the transcript
+  createWordArray(words) {
+    return Array.from(words).map(word => {
+      const m = parseInt(word.getAttribute('data-m'));
+      let p = word.parentNode;
+      while (p !== document) {
+        if (['p', 'figure', 'ul'].includes(p.tagName.toLowerCase())) {
+          break;
+        }
+        p = p.parentNode;
+      }
+      word.classList.add('unread');
+      return { n: word, m, p };
+    });
+  }
+
+  getSelectionRange = () => {
+    const selection = window.getSelection();
+    if (selection.rangeCount === 0) return null;
+
+    const range = selection.getRangeAt(0);
+    
+    // Helper function to get the closest span
+    function getClosestSpan(node) {
+      while (node && node.nodeType !== Node.ELEMENT_NODE) {
+        node = node.parentNode;
+      }
+      return node.closest('[data-m]');
+    }
+
+    // Get all relevant spans
+    const allSpans = Array.from(this.transcript.querySelectorAll('[data-m]'));
+
+    // Find the first and last span that contain selected text
+    let startSpan = null;
+    let endSpan = null;
+    let selectedText = range.toString();
+    let trimmedSelectedText = selectedText.trim();
+
+    for (let span of allSpans) {
+      if (range.intersectsNode(span) && span.textContent.trim() !== '') {
+        if (!startSpan) startSpan = span;
+        endSpan = span;
+      }
+    }
+
+    if (!startSpan || !endSpan) return null;
+
+    // Adjust start span if selection starts with a space
+    let startIndex = allSpans.indexOf(startSpan);
+    while (selectedText.startsWith(' ') && startIndex < allSpans.length - 1) {
+      startIndex++;
+      startSpan = allSpans[startIndex];
+      selectedText = selectedText.slice(1);
+    }
+
+    // Calculate start time
+    let startTime = parseInt(startSpan.dataset.m) / 1000;
+
+    // Calculate end time
+
+    let duration = 0;
+    if (endSpan.dataset.d) {
+      duration = parseInt(endSpan.dataset.d);
+    } else {
+      // when no duration exists default to 1 second
+      duration = 1000; 
+    }
+
+    let endTime = (parseInt(endSpan.dataset.m) + duration) / 1000;
+
+    // Format to seconds at 2 decimal place precision
+    let startTimeFormatted = (Math.round(startTime * 100) / 100).toFixed(2);
+    let endTimeFormatted = (Math.round(endTime * 100) / 100).toFixed(2);
+
+    // Only return a range if there's actually selected text (excluding only spaces)
+    return trimmedSelectedText ? `${startTimeFormatted},${endTimeFormatted}` : null;
+  }
+
+  getSelectionMediaFragment = () => {
+    let range = this.getSelectionRange();
+    if (range === null) {
+      return null;
+    }
+    console.log(range);
+    return (this.transcript.id + '=' +range);
+  }
+
+  // Set the playhead position in the media player based on the transcript
+  setPlayHead(e) {
+    const target = e.target || e.srcElement;
+    this.highlightedText = false;
+    this.clearActiveClasses();
+
+    if (this.myPlayer.paused && target.dataset.m) {
+      target.classList.add('active');
+      target.parentNode.classList.add('active');
+    }
+
+    const timeSecs = parseInt(target.dataset.m) / 1000;
+    this.updateTranscriptVisualState(timeSecs);
+
+    if (!isNaN(timeSecs)) {
+      this.end = null;
+      this.myPlayer.setTime(timeSecs);
+      if (this.playOnClick) {
+        this.myPlayer.play();
+      }
+    }
+  }
+
+  // Clear the active classes from the transcript
+  clearActiveClasses() {
+    const activeElements = Array.from(this.transcript.getElementsByClassName('active'));
+    activeElements.forEach(e => e.classList.remove('active'));
+  }
+
+  // Prepare the playhead for playback
+  preparePlayHead() {
+    this.myPlayer.paused = false;
+    this.checkPlayHead();
+  }
+
+  // Pause the playhead
+  pausePlayHead() {
+    this.clearTimer();
+    this.myPlayer.paused = true;
+  }
+
+  // Check the playhead position and update the transcript
+  checkPlayHead() {
+    this.clearTimer();
+
+    (async () => {
+      this.currentTime = await this.myPlayer.getTime();
+      if (this.highlightedText) {
+        this.currentTime = this.start;
+        this.myPlayer.setTime(this.currentTime);
+        this.highlightedText = false;
+      }
+      this.checkStatus();
+    })();
+  }
+
+  // Clear the timer for the playhead
+  clearTimer() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  scrollToParagraph(currentParentElementIndex, index) {
+    if (currentParentElementIndex !== this.parentElementIndex) {
+      if (this.autoscroll) {
+        const currentParagraph = this.parentElements[currentParentElementIndex];
+        if (currentParagraph) {
+          const containerRect = this.scrollContainer.getBoundingClientRect();
+          const paragraphRect = currentParagraph.getBoundingClientRect();
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
+          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
+        }
+      }
+      this.parentElementIndex = currentParentElementIndex;
+    }
+  }
+
+  smoothScrollTo(container, targetTop, duration) {
+    if (this.scrollAnimationId) {
+      cancelAnimationFrame(this.scrollAnimationId);
+    }
+    const startTop = container.scrollTop;
+    const distance = targetTop - startTop;
+    if (distance === 0) return;
+    const startTime = performance.now();
+    const easeInOutCubic = t => t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+    const step = now => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      container.scrollTop = startTop + distance * easeInOutCubic(progress);
+      if (progress < 1) {
+        this.scrollAnimationId = requestAnimationFrame(step);
+      } else {
+        this.scrollAnimationId = null;
+      }
+    };
+    this.scrollAnimationId = requestAnimationFrame(step);
+  }
+
+
+  // Check the status of the playhead and update the transcript
+  checkStatus() {
+    if (!this.myPlayer.paused) {
+      if (this.end && parseInt(this.end) < parseInt(this.currentTime)) {
+        this.myPlayer.pause();
+        this.end = null;
+      } else {
+        const indices = this.updateTranscriptVisualState(this.currentTime);
+        const index = indices.currentWordIndex;
+
+        if (index > 0 && this.autoscroll) {
+          this.scrollToParagraph(indices.currentParentElementIndex, index);
+        }
+
+        if (this.minimizedMode) {
+          const elements = this.transcript.querySelectorAll('[data-m]');
+          let currentWord = '';
+          let lastWordIndex = this.wordIndex;
+
+          for (let i = 0; i < elements.length; i++) {
+            if (elements[i].classList.contains('active')) {
+              currentWord = elements[i].innerHTML;
+              this.wordIndex = i;
+            }
+          }
+
+          if (this.wordIndex !== lastWordIndex) {
+            document.title = currentWord;
+          }
+        }
+
+        if (this.webMonetization === true) {
+          let activeElements = this.transcript.getElementsByClassName('active');
+          let paymentPointer = this.checkPaymentPointer(activeElements[activeElements.length - 1]);
+
+          if (paymentPointer !== null) {
+            let wmLink = document.querySelector("link[rel='monetization']");
+            if (wmLink === null) {
+              wmLink = document.createElement('link');
+              wmLink.rel = 'monetization';
+              wmLink.href = paymentPointer;
+              document.getElementsByTagName('head')[0].appendChild(wmLink);
+            } else {
+              wmLink.href = paymentPointer;
+            }
+          }
+        }
+
+        let interval = 0;
+        if (this.wordArr[index]) {
+          interval = this.wordArr[index].n.getAttribute('data-m') - this.currentTime * 1000;
+        }
+
+        this.timer = setTimeout(() => this.checkPlayHead(), interval + 1);
+      }
+    } else {
+      this.clearTimer();
+    }
+  }
+
+  checkPaymentPointer = element => {
+    let paymentPointer = null;
+
+    if (typeof(element) != "undefined") {
+      paymentPointer = element.getAttribute('data-wm');
+    }
+
+    if (paymentPointer !== null) {
+      return paymentPointer;
+    } else {
+      let parent = null;
+
+      if (typeof element !== 'undefined') {
+        parent = element.parentElement;
+      }
+
+      if (parent === null) {
+        return null;
+      } else {
+        return this.checkPaymentPointer(parent);
+      }
+    }
+  }
+
+  // Update the visual state of the transcript based on the current time
+  updateTranscriptVisualState(currentTime) {
+    let index = 0;
+    let words = this.wordArr.length - 1;
+
+    while (index <= words) {
+      const guessIndex = index + ((words - index) >> 1);
+      const difference = this.wordArr[guessIndex].m / 1000 - currentTime;
+
+      if (difference < 0) {
+        index = guessIndex + 1;
+      } else if (difference > 0) {
+        words = guessIndex - 1;
+      } else {
+        index = guessIndex;
+        break;
+      }
+    }
+
+    this.wordArr.forEach((word, i) => {
+      const classList = word.n.classList;
+      const parentClassList = word.n.parentNode.classList;
+
+      if (i < index) {
+        classList.add('read');
+        classList.remove('unread', 'active');
+        parentClassList.remove('active');
+      } else {
+        classList.add('unread');
+        classList.remove('read');
+      }
+    });
+
+    this.parentElements = this.transcript.getElementsByTagName(this.parentTag);
+    Array.from(this.parentElements).forEach(el => el.classList.remove('active'));
+
+    if (index > 0) {
+      if (!this.myPlayer.paused) {
+        this.wordArr[index - 1].n.classList.add('active');
+      }
+      this.wordArr[index - 1].n.parentNode.classList.add('active');
+    }
+  
+    const currentParentElementIndex = Array.from(this.parentElements).findIndex(el => el.classList.contains('active'));
+
+    return {
+      currentWordIndex: index,
+      currentParentElementIndex
+    };
+  }
+}
+
+// Export for testing or module usage
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { HyperaudioLite };
+}
+
+// TEMPORARY local addition: ESM export so Vite-bundled Astro scripts can
+// `import { HyperaudioLite } from "@/lib/hyperaudio-lite.js"`. Remove once
+// upstream ships a sibling hyperaudio-lite.mjs we can depend on directly.
+export { HyperaudioLite };

--- a/src/lib/transcript-json.ts
+++ b/src/lib/transcript-json.ts
@@ -1,0 +1,111 @@
+// Canonical JSON shape for interactive transcripts in this repo.
+// Same shape we'll propose for the AT Proto / Standard.site lexicon —
+// see ../../content/transcripts/README.md for context.
+
+export interface TranscriptWord {
+  start: number; // seconds
+  end: number; // seconds
+  text: string; // word as it should render (punctuation kept; whitespace trimmed)
+}
+
+export interface TranscriptParagraph {
+  start: number; // seconds
+  end: number; // seconds
+  speaker?: string; // free-form id or name; omit when unknown
+}
+
+export interface TranscriptJson {
+  words: TranscriptWord[];
+  paragraphs: TranscriptParagraph[];
+}
+
+const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const toMs = (s: number): number => Math.round(s * 1000);
+
+/**
+ * Render a JSON transcript to HAL-compatible HTML.
+ *
+ * Output shape: <article><section><p data-speaker?>...</p>...</section></article>
+ * Word spans carry data-m (start ms) and data-d (duration ms) — the only
+ * attributes HAL parses.
+ *
+ * Words are bucketed into paragraphs by `word.start` falling within
+ * [paragraph.start, paragraph.end]. Words outside all paragraph ranges are
+ * dropped silently (with a one-line warning at build time so authors notice).
+ */
+export function transcriptJsonToHtml(data: TranscriptJson): string {
+  const { words, paragraphs } = data;
+  if (!Array.isArray(words) || !Array.isArray(paragraphs)) {
+    throw new Error("Transcript JSON must have words[] and paragraphs[]");
+  }
+
+  // Bucket words into paragraphs in a single pass (assumes both arrays are
+  // chronologically sorted, which is the natural authoring order).
+  // For a word at time T, pick the latest paragraph whose [start, end]
+  // contains T — when two paragraphs touch at a boundary (e.g. a speaker
+  // change at exactly T), the boundary word belongs to the new speaker.
+  const buckets: TranscriptWord[][] = paragraphs.map(() => []);
+  let pIdx = 0;
+  let dropped = 0;
+
+  for (const w of words) {
+    // Advance to the first paragraph whose end is at or after the word.
+    while (pIdx < paragraphs.length && w.start > paragraphs[pIdx].end) {
+      pIdx++;
+    }
+    if (pIdx >= paragraphs.length) {
+      dropped++;
+      continue;
+    }
+    // Prefer the latest paragraph whose start is at or before the word.
+    while (
+      pIdx + 1 < paragraphs.length &&
+      paragraphs[pIdx + 1].start <= w.start
+    ) {
+      pIdx++;
+    }
+    if (w.start < paragraphs[pIdx].start) {
+      dropped++;
+      continue;
+    }
+    buckets[pIdx].push(w);
+  }
+
+  if (dropped > 0 && typeof console !== "undefined") {
+    console.warn(
+      `[transcript] ${dropped} word(s) fell outside paragraph ranges and were dropped.`,
+    );
+  }
+
+  const parts: string[] = ["<article>", "<section>"];
+  for (let i = 0; i < paragraphs.length; i++) {
+    const bucket = buckets[i];
+    if (bucket.length === 0) continue;
+    const p = paragraphs[i];
+
+    const speakerAttr = p.speaker
+      ? ` data-speaker="${escapeHtml(p.speaker)}"`
+      : "";
+    parts.push(`<p${speakerAttr}>`);
+    if (p.speaker) {
+      parts.push(`<strong class="speaker">${escapeHtml(p.speaker)}</strong> `);
+    }
+    for (const w of bucket) {
+      const m = toMs(w.start);
+      const d = Math.max(0, toMs(w.end) - m);
+      parts.push(
+        `<span data-m="${m}" data-d="${d}">${escapeHtml(w.text)} </span>`,
+      );
+    }
+    parts.push("</p>");
+  }
+  parts.push("</section>", "</article>");
+  return parts.join("");
+}

--- a/src/pages/event/[id].astro
+++ b/src/pages/event/[id].astro
@@ -11,6 +11,18 @@ import remoteBadgeSvg from "@/components/ui/icons/RemoteBadge.svg?raw";
 import inPersonIconSvg from "@/components/ui/icons/InPersonIcon.svg?raw";
 import { isRemoteAccessible } from "@/lib/calendar-event";
 import VodPlayer from "@/components/ui/VodPlayer.astro";
+import InteractiveTranscript from "@/components/InteractiveTranscript.astro";
+import {
+  transcriptJsonToHtml,
+  type TranscriptJson,
+} from "@/lib/transcript-json";
+
+// Vite parses .json imports into objects at build time; with eager:false we
+// get a per-file lazy loader, then choose by slug at request time.
+const transcriptModules = import.meta.glob<TranscriptJson>(
+  "/src/content/transcripts/*.json",
+  { import: "default", eager: false },
+);
 
 const { id } = Astro.params;
 const user = Astro.locals.loggedInUser;
@@ -78,6 +90,12 @@ const dateDisplay = start ? formatConferenceDay(start) : null;
 
 const streamTrack = isRemoteAccessible(mode)
   ? streamTracks.find((t) => t.room === room)
+  : null;
+
+const transcriptLoader =
+  transcriptModules[`/src/content/transcripts/${id}.json`];
+const transcriptHtml = transcriptLoader
+  ? transcriptJsonToHtml(await transcriptLoader())
   : null;
 ---
 
@@ -241,6 +259,12 @@ const streamTrack = isRemoteAccessible(mode)
         {vodAtUri && (
           <div class="mt-6">
             <VodPlayer vodAtUri={vodAtUri} title={plainTitle} />
+            {transcriptHtml && id && (
+              <InteractiveTranscript
+                uid={id}
+                transcriptHtml={transcriptHtml}
+              />
+            )}
           </div>
         )}
       </Card>


### PR DESCRIPTION
## Summary
- Word-level interactive transcript pane on `/event/{slug}` when a JSON file exists at `src/content/transcripts/{slug}.json`; clicking words seeks playback, scrubbing the player advances the highlighted word, and Plyr's CC button surfaces WebVTT captions generated from the same data.
- Word-range deeplinks via `#clip=START,END` — selecting text shows a small popover with **Copy link** / **Copy with quote**; loading a clip URL auto-seeks, highlights the range in muted workshop-green, and auto-pauses at the end.
- JSON-first storage (`{ words, paragraphs[+speaker?] }`) so the same data flows into the planned Phase 2 Leaflet hypertranscript block without conversion. `rjQ96kl` (Daniel Holmgren — *Protocol Governance & Hard Decentralization*) is included as a worked example.

## Test plan
- [ ] `/event/rjQ96kl` — transcript pane renders below the video
- [ ] Word click → video seeks + plays; Plyr progress matches
- [ ] Playback → highlighted word advances through the transcript
- [ ] Scrub Plyr while playing → highlight follows
- [ ] Scrub Plyr while paused → highlight still follows
- [ ] Select a phrase → popover appears after mouse release (not during the drag)
- [ ] **Copy link** → clipboard receives `…/event/rjQ96kl#clip=START,END`
- [ ] **Copy with quote** → clipboard receives `"<selected>"\n\n<URL>`
- [ ] Open a clip URL fresh → transcript scrolls to range, range is muted-green highlighted, playback seeks + auto-pauses at end
- [ ] Plyr CC button → captions render over the video
- [ ] Any event page without a transcript file → renders unchanged, no CC button
- [ ] Cross-browser: Chrome, Firefox, Safari (desktop + mobile)

## Notes
- HAL (`src/lib/hyperaudio-lite.js`) and `caption.js` are vendored from upstream v2.4.2 with a one-line `export { ... }` ESM shim. Marked TEMPORARY in comments — the plan is to ship an importable sibling `.mjs` upstream and drop the vendored copies once that lands.
- See `src/content/transcripts/README.md` for the architecture write-up, JSON schema, and instructions for adding more transcripts.