### PR TITLE
fix: point VOD playback at stream.place

### DIFF
--- a/src/components/ui/VodPlayer.astro
+++ b/src/components/ui/VodPlayer.astro
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const VOD_PLAYBACK_BASE =
-  "https://vod-beta.stream.place/xrpc/place.stream.playback.getVideoPlaylist";
+  "https://stream.place/xrpc/place.stream.playback.getVideoPlaylist";
 
 const { vodAtUri, title } = Astro.props;
 const playlistUrl = `${VOD_PLAYBACK_BASE}?uri=${encodeURIComponent(vodAtUri)}`;


### PR DESCRIPTION
## Summary
Replace the dead `https://vod-beta.stream.place` host with `https://stream.place` in `VodPlayer.astro`. Per #121, this is the working endpoint.

Verified: `https://stream.place/xrpc/place.stream.playback.getVideoPlaylist?uri=...` returns valid HLS master playlists (`#EXTM3U`, 1080p variant + AAC audio track) for atmosphereconf VOD URIs.

## Test plan
- [ ] Visit any `/event/{id}` page that has a `vodAtUri` (e.g. `/event/rjQ96kl`, `/event/ats26-keynote`)
- [ ] Network tab shows a request to `stream.place/xrpc/place.stream.playback.getVideoPlaylist?uri=...` returning `application/vnd.apple.mpegurl`
- [ ] Video plays

Closes #121.