### PR TITLE
fix: show transcript share popover on mobile

### DIFF
--- a/src/components/InteractiveTranscript.astro
+++ b/src/components/InteractiveTranscript.astro
@@ -220,10 +220,22 @@ const transcriptId = "clip";
       document.addEventListener("mouseup", showIfValidSelection);
       document.addEventListener("touchend", showIfValidSelection);
 
-      // Hide as soon as the selection collapses (e.g. user clicks elsewhere).
+      // Mobile: selection happens via long-press + dragging the native
+      // selection handles, which never yields a post-selection touchend on
+      // the document — the mouseup/touchend path above never fires with a
+      // live selection. Debounce selectionchange instead: once the selection
+      // stops changing for a beat, show the popover if it's valid. The
+      // debounce also avoids the mid-drag flicker that showing from raw
+      // selectionchange would cause. Collapse still hides immediately.
+      let selectionSettleTimer = 0;
       document.addEventListener("selectionchange", () => {
         const selection = window.getSelection();
-        if (!selection || selection.isCollapsed) hideSharePopover();
+        if (!selection || selection.isCollapsed) {
+          hideSharePopover();
+          return;
+        }
+        window.clearTimeout(selectionSettleTimer);
+        selectionSettleTimer = window.setTimeout(showIfValidSelection, 350);
       });
 
       // Track the selection while the transcript (or the page) scrolls so
@@ -271,12 +283,7 @@ const transcriptId = "clip";
       };
 
       popoverBtns.forEach((btn) => {
-        // mousedown.preventDefault keeps the document selection alive when
-        // the user clicks the button — otherwise focus shifts and the
-        // selection collapses before our click handler runs.
-        btn.addEventListener("mousedown", (e) => e.preventDefault());
-
-        btn.addEventListener("click", async () => {
+        const runCopyAction = async () => {
           const fragment = hal.getSelectionMediaFragment();
           if (!fragment) return;
           const url = `${location.origin}${location.pathname}#${fragment}`;
@@ -292,6 +299,20 @@ const transcriptId = "clip";
           } else {
             await copyToClipboard(url, btn);
           }
+        };
+
+        // mousedown.preventDefault keeps the document selection alive when
+        // the user clicks the button — otherwise focus shifts and the
+        // selection collapses before our click handler runs.
+        btn.addEventListener("mousedown", (e) => e.preventDefault());
+        btn.addEventListener("click", runCopyAction);
+
+        // Touch equivalent: preventDefault on touchend suppresses the
+        // synthesized click/focus that would collapse the selection on
+        // mobile, so invoke the action directly from here instead.
+        btn.addEventListener("touchend", (e) => {
+          e.preventDefault();
+          runCopyAction();
         });
       });
     });


### PR DESCRIPTION
Closes #127.

## Problem
Selecting transcript text on mobile (iOS Safari, Android Chrome) never showed the **Copy link / Copy with quote** popover. Two compounding causes:

1. The popover was only shown from `mouseup`/`touchend` — but mobile selection (long-press + dragging the native selection handles) never yields a post-selection `touchend` on the document. The `touchend` that does fire (lifting after the long-press) arrives before the selection exists.
2. The buttons kept the selection alive with `mousedown.preventDefault()`, which does nothing for touch — tapping a button collapsed the selection before the handler could read it, so even a visible popover couldn't have copied anything.

## Fix
- **Debounced `selectionchange`** (350 ms after the selection settles) now also shows the popover when the selection is valid and inside the transcript. Covers handle-drag selection on mobile without the mid-drag flicker that raw `selectionchange` would cause. Desktop keeps the instant `mouseup` path.
- Buttons additionally handle **`touchend` with `preventDefault()`** and invoke the copy action directly — suppressing the synthesized click/focus that would collapse the selection, mirroring what `mousedown.preventDefault()` does for mouse.

## Test plan
- [ ] **Mobile (real device)**: long-press a word in a transcript → drag handles to extend → popover appears ~⅓s after you stop → tap *Copy link* → URL with `#clip=…` lands on the clipboard; *Copy with quote* includes the selected text
- [ ] Mobile: tap elsewhere → popover hides
- [ ] Desktop regression: select with mouse → popover appears immediately on release; both buttons still work; popover hides on click-away and tracks scroll
- [ ] Clipboard fallback (non-secure context): hash written to URL bar

Railway preview + a phone is the easiest way to test the mobile path.