### PR TITLE
feat(2027): add Sifa theme to airmail palette

### DIFF
--- a/sites/2027/src/components/ThemeSwitcher.astro
+++ b/sites/2027/src/components/ThemeSwitcher.astro
@@ -58,6 +58,7 @@
 			blacksky: { label: "Blacksky", image: "goose" },
 			semble: { label: "Semble", image: "goose" },
 			fujocoded: { label: "Fujocoded", image: "goose" },
+			sifa: { label: "Sifa", image: "goose" },
 		};
 
 		const themeKeys = Object.keys(themes);

--- a/sites/2027/src/styles/airmail.css
+++ b/sites/2027/src/styles/airmail.css
@@ -95,6 +95,15 @@ body[data-palette="fujocoded"] {
 	--cancel-stamp: #4360f7;
 }
 
+body[data-palette="sifa"] {
+	--ink: #143a5e;
+	--strong: #205ea6;
+	--sky: #a9d2ed;
+	--butter: #e4dcf6;
+	--mint: #c4b4e8;
+	--paper: #fffcf0;
+}
+
 button,
 input {
 	font: inherit;


### PR DESCRIPTION
Adds a Sifa palette to the 2027 airmail theme system, alongside the existing sky, garden, colibri, blacksky, semble, and fujocoded options.

Sifa (sifa.id) is a professional network on AT Protocol. The palette uses its Flexoki brand colors: a deep blue ink, Flexoki Blue as the strong accent, a soft blue page wash, Flexoki Purple for the secondary and selection tones, and the Flexoki paper surface.

Two changes, matching how the other themes are defined:
- `ThemeSwitcher.astro`: add `sifa` to the theme cycle
- `airmail.css`: add the `body[data-palette="sifa"]` variable block

Cycle the theme toggle to "Sifa" to preview, or set `document.body.dataset.palette = "sifa"`.
