### PR TITLE
fix(2027): remove stray "or" in postcard subscribe tip

### DIFF
--- a/sites/2027/src/components/postcard/PostcardForm.astro
+++ b/sites/2027/src/components/postcard/PostcardForm.astro
@@ -69,7 +69,7 @@ const subscriptionResult = await takeSubscriptionResult(
 	<label class="tip" for="airmail-email">
 		Whether via <span class="email">email</span> or <span class="handle"
 			>Atmosphere handle</span
-		> or, our news reaches you all across the web.
+		>, our news reaches you all across the web.
 	</label>
 	<button class="subscribe" type="submit"
 		>Keep me posted <span aria-hidden="true">↗</span></button


### PR DESCRIPTION
Fixes a stray "or" in the postcard subscribe tip on the 2027 site.

Before: "Whether via email or Atmosphere handle or, our news reaches you all across the web."
After: "Whether via email or Atmosphere handle, our news reaches you all across the web."
